### PR TITLE
Fix HTML string assembly bug

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -30,7 +30,7 @@ export default class Renderer {
   createUnit(type, label) {
     const el = document.createElement('div');
     el.classList.add('unit', type);
-      el.innerHTML = "<div class="label">" + label + "</div><div class="hp-bar"><div class="fill"></div></div>";
+    el.innerHTML = `<div class="label">${label}</div><div class="hp-bar"><div class="fill"></div></div>`;
     this.boardEl.appendChild(el);
     return el;
   }


### PR DESCRIPTION
## Summary
- fix quoting in `createUnit` so units render correctly

## Testing
- `node renderer.js` *(parses without syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_686e2b3f78c0832dbe02b1bb08c14f60