### PR TITLE
Add infinite procedural levels with obstacles

### DIFF
--- a/js/board.js
+++ b/js/board.js
@@ -1,6 +1,6 @@
 import { PIECES } from './utils.js';
 
-export const levels = [
+export const baseLevels = [
     {
         start: { row: 0, col: 0, dir: 'right' },
         end: { row: 0, col: 5 },
@@ -16,6 +16,43 @@ export const levels = [
         ]
     }
 ];
+
+export function getLevel(index) {
+    if (index < baseLevels.length) {
+        return baseLevels[index];
+    }
+    return generateLevel(index);
+}
+
+function generateLevel(levelIndex) {
+    const start = { row: 0, col: 0, dir: 'right' };
+    const end = { row: 5, col: 5 };
+    const prefilled = [];
+    const used = new Set(['0,0', '5,5']);
+    const obstacleCount = Math.min(4 + levelIndex, 20);
+    while (prefilled.length < obstacleCount) {
+        const r = Math.floor(Math.random() * 6);
+        const c = Math.floor(Math.random() * 6);
+        const key = `${r},${c}`;
+        if (used.has(key)) continue;
+        used.add(key);
+        prefilled.push({ row: r, col: c, piece: 7, locked: true });
+    }
+    const lockedPieces = Math.min(2 + Math.floor(levelIndex / 2), 10);
+    const pieces = [1, 2, 3, 4, 5, 6];
+    for (let i = 0; i < lockedPieces; i++) {
+        let r, c, key;
+        do {
+            r = Math.floor(Math.random() * 6);
+            c = Math.floor(Math.random() * 6);
+            key = `${r},${c}`;
+        } while (used.has(key));
+        used.add(key);
+        const p = pieces[Math.floor(Math.random() * pieces.length)];
+        prefilled.push({ row: r, col: c, piece: p, locked: true });
+    }
+    return { start, end, prefilled };
+}
 
 export function createBoard(container, state, level) {
     container.innerHTML = '';
@@ -44,7 +81,15 @@ export function createBoard(container, state, level) {
 
     for (const item of level.prefilled) {
         const idx = item.row * 6 + item.col;
-        cells[idx].textContent = PIECES[item.piece];
+        const cell = cells[idx];
+        cell.textContent = PIECES[item.piece];
         state.grid[item.row][item.col] = item.piece;
+        if (item.locked) {
+            cell.classList.add('locked');
+            cell.dataset.locked = 'true';
+        }
+        if (item.piece === 7) {
+            cell.classList.add('blocked');
+        }
     }
 }

--- a/js/game.js
+++ b/js/game.js
@@ -1,5 +1,5 @@
 import { PIECES, CONNECTIONS, opposite } from './utils.js';
-import { levels, createBoard } from './board.js';
+import { getLevel, createBoard } from './board.js';
 
 const boardEl = document.getElementById('board');
 const messageEl = document.getElementById('message');
@@ -17,12 +17,7 @@ function init() {
 }
 
 function loadLevel(index) {
-    const level = levels[index];
-    if (!level) {
-        messageEl.textContent = '¡Has completado todos los niveles!';
-        boardEl.innerHTML = '';
-        return;
-    }
+    const level = getLevel(index);
     boardEl.classList.remove('success', 'fail');
     messageEl.textContent = '';
     createBoard(boardEl, state, level);
@@ -30,7 +25,13 @@ function loadLevel(index) {
 
 function handleCellClick(e) {
     const cell = e.target.closest('.cell');
-    if (!cell || cell.classList.contains('start') || cell.classList.contains('end')) {
+    if (
+        !cell ||
+        cell.classList.contains('start') ||
+        cell.classList.contains('end') ||
+        cell.classList.contains('locked') ||
+        cell.classList.contains('blocked')
+    ) {
         return;
     }
     const r = parseInt(cell.dataset.row);
@@ -49,8 +50,7 @@ function inBounds(row, col) {
 }
 
 function verify() {
-    const level = levels[state.levelIndex];
-    if (!level) return;
+    const level = getLevel(state.levelIndex);
     const visited = new Set();
     let pos = { row: level.start.row, col: level.start.col };
     let dir = level.start.dir;
@@ -70,7 +70,7 @@ function verify() {
         if (!piece) return fail();
         const connectors = CONNECTIONS[piece];
         const needed = opposite(dir);
-        if (!connectors.includes(needed)) return fail();
+        if (!connectors || !connectors.includes(needed)) return fail();
         dir = connectors[0] === needed ? connectors[1] : connectors[0];
         pos = next;
     }

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,4 +1,4 @@
-export const PIECES = ['', '─', '│', '┐', '└', '┘', '┌'];
+export const PIECES = ['', '─', '│', '┐', '└', '┘', '┌', '❌'];
 
 export const CONNECTIONS = {
     '─': ['left', 'right'],

--- a/style.css
+++ b/style.css
@@ -54,6 +54,17 @@ h1 {
     cursor: default;
 }
 
+.cell.locked {
+    background: #eee;
+    cursor: default;
+}
+
+.cell.blocked {
+    background: #333;
+    color: #fff;
+    cursor: default;
+}
+
 #message {
     margin-top: 10px;
     min-height: 20px;


### PR DESCRIPTION
## Summary
- generate levels dynamically with `getLevel` and `generateLevel`
- allow obstacle and locked cells
- prevent interaction with locked/blocked pieces
- show blocked cells using a new `❌` piece
- style locked and blocked cells

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e3077a8bc832d9300d9ce27cdc06b