### PR TITLE
Validación automática del dataset léxico en el arranque

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,8 @@
 import { createExerciseEngine } from './src/core/exerciseEngine.js';
 import { state, resetAnswerState } from './src/core/state.js';
 import { renderExerciseMeta, renderQuestionUI, setFeedback } from './src/ui/render.js';
+import { WORDS } from './src/data/words/index.js';
+import { validateWords } from './src/core/validateWords.js';
 
 const EXERCISES = {
   count: { title: 'Contar sílabas', type: 'Conciencia silábica' },
@@ -68,6 +70,7 @@ function initEvents() {
 }
 
 function initApp() {
+  validateWords(WORDS);
   engine.setDifficulty(1);
   initEvents();
   generateNewRound();

--- a/src/core/validateWords.js
+++ b/src/core/validateWords.js
@@ -1,0 +1,135 @@
+const ALLOWED_CATEGORIES = new Set([
+  'animales',
+  'hogar',
+  'comida',
+  'escuela',
+  'cuerpo',
+  'juguetes',
+  'ropa',
+  'naturaleza'
+]);
+
+const ALLOWED_DIFFICULTIES = new Set([1, 2, 3, 4]);
+const ID_PATTERN = /^lvl\d+_[a-z]+_[a-z0-9áéíóúüñ]+$/i;
+
+function logWordsError(message) {
+  console.error('[WORDS ERROR]');
+  console.error(message);
+}
+
+function logWordsWarning(message) {
+  console.warn('[WORDS WARNING]');
+  console.warn(message);
+}
+
+export function validateWords(words) {
+  if (!Array.isArray(words)) {
+    logWordsError('Dataset is not an array.');
+    return { errors: 1, warnings: 0 };
+  }
+
+  let errors = 0;
+  let warnings = 0;
+
+  const ids = new Map();
+  const wordsByValue = new Map();
+
+  words.forEach((entry, index) => {
+    const ref = entry?.word || `index:${index}`;
+
+    if (!entry || typeof entry !== 'object') {
+      errors += 1;
+      logWordsError(`Invalid word entry at index ${index}.`);
+      return;
+    }
+
+    if (!entry.id || typeof entry.id !== 'string' || entry.id.trim() === '') {
+      errors += 1;
+      logWordsError(`Empty id in word: ${ref}`);
+    } else {
+      const normalizedId = entry.id.trim();
+
+      if (!ID_PATTERN.test(normalizedId)) {
+        errors += 1;
+        logWordsError(`Malformed id: ${entry.id}`);
+      }
+
+      if (ids.has(normalizedId)) {
+        errors += 1;
+        logWordsError(`Duplicate id: ${normalizedId}`);
+      } else {
+        ids.set(normalizedId, entry);
+      }
+    }
+
+    if (!entry.word || typeof entry.word !== 'string' || entry.word.trim() === '') {
+      errors += 1;
+      logWordsError(`Empty word value in id: ${entry.id || `index:${index}`}`);
+    } else {
+      const normalizedWord = entry.word.trim().toLowerCase();
+      if (!wordsByValue.has(normalizedWord)) {
+        wordsByValue.set(normalizedWord, []);
+      }
+      wordsByValue.get(normalizedWord).push(entry);
+    }
+
+    if (!entry.category || typeof entry.category !== 'string' || entry.category.trim() === '') {
+      errors += 1;
+      logWordsError(`Empty category in word: ${ref}`);
+    } else if (!ALLOWED_CATEGORIES.has(entry.category.trim().toLowerCase())) {
+      warnings += 1;
+      logWordsWarning(`Category not allowed in word ${ref}: ${entry.category}`);
+    }
+
+    if (!entry.structure || typeof entry.structure !== 'string' || entry.structure.trim() === '') {
+      errors += 1;
+      logWordsError(`Empty structure in word: ${ref}`);
+    }
+
+    if (!ALLOWED_DIFFICULTIES.has(entry.difficulty)) {
+      errors += 1;
+      logWordsError(`Invalid difficulty in word ${ref}: ${entry.difficulty}`);
+    }
+
+    if (!Array.isArray(entry.syllables) || entry.syllables.length === 0) {
+      errors += 1;
+      logWordsError(`Empty syllables array in word: ${ref}`);
+      return;
+    }
+
+    if (entry.syllableCount !== entry.syllables.length) {
+      errors += 1;
+      logWordsError(`Incorrect syllableCount in word: ${ref}`);
+    }
+
+    if (entry.initialSyllable !== entry.syllables[0]) {
+      errors += 1;
+      logWordsError(`Incorrect initialSyllable in word: ${ref}`);
+    }
+
+    if (entry.finalSyllable !== entry.syllables[entry.syllables.length - 1]) {
+      errors += 1;
+      logWordsError(`Incorrect finalSyllable in word: ${ref}`);
+    }
+  });
+
+  wordsByValue.forEach((entries, normalizedWord) => {
+    if (entries.length > 1) {
+      const categories = [...new Set(entries.map((item) => item.category || 'sin-categoría'))].join(', ');
+      warnings += 1;
+      logWordsWarning(
+        `Duplicate word detected: ${normalizedWord}. Categories: ${categories}. IDs: ${entries
+          .map((item) => item.id)
+          .join(', ')}`
+      );
+    }
+  });
+
+  if (errors === 0 && warnings === 0) {
+    console.info('[WORDS OK] Dataset validation completed without issues.');
+  } else {
+    console.info(`[WORDS CHECK] Completed with ${errors} error(s) and ${warnings} warning(s).`);
+  }
+
+  return { errors, warnings };
+}


### PR DESCRIPTION
### Motivation
- Garantizar la consistencia y calidad del dataset léxico evitando errores silenciosos al crecer el catálogo de palabras.
- Detectar automáticamente problemas comunes (IDs duplicados/mal formados, entradas inconsistentes, duplicados por valor) para facilitar la limpieza y mantenimiento.
- Ejecutar la validación al iniciar la app como una puerta de calidad sin cambiar la UI ni añadir backend/Firebase o nuevas pantallas.

### Description
- Se añadió `src/core/validateWords.js` que valida todo el dataset comprobando IDs (vacíos, mal formados, duplicados), palabras duplicadas por valor, categoría vacía o no permitida, estructura vacía y arrays de `syllables` vacíos.
- El validador verifica además `difficulty` contra los valores permitidos, `syllableCount === syllables.length`, `initialSyllable === syllables[0]` y `finalSyllable === syllables[syllables.length - 1]`.
- Definidas reglas: patrón de ID (`/^lvl\d+_[a-z]+_[a-z0-9áéíóúüñ]+$/i`), lista de categorías permitidas (`animales, hogar, comida, escuela, cuerpo, juguetes, ropa, naturaleza`) y dificultades permitidas (`1,2,3,4`).
- Integrado en el arranque de la app al importar `WORDS` y llamar a `validateWords(WORDS)` desde `initApp()` sin tocar la interfaz visual.

### Testing
- Ejecutado `node --check main.js` y la comprobación de sintaxis pasó correctamente.
- Ejecutado `node --check src/core/validateWords.js` y la comprobación de sintaxis pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc6cb7448832d8f5decedd4b567cf)