### PR TITLE
Add `frequency` metadata to all word entries

### DIFF
--- a/src/data/words/animals.js
+++ b/src/data/words/animals.js
@@ -7,6 +7,7 @@ export const level1Animals = [
     initialSyllable: "pa",
     finalSyllable: "to",
     difficulty: 1,
+    frequency: 1,
     category: "animales",
     structure: "CV-CV",
     image: null
@@ -19,6 +20,7 @@ export const level1Animals = [
     initialSyllable: "ga",
     finalSyllable: "to",
     difficulty: 1,
+    frequency: 1,
     category: "animales",
     structure: "CV-CV",
     image: null
@@ -31,6 +33,7 @@ export const level1Animals = [
     initialSyllable: "mo",
     finalSyllable: "no",
     difficulty: 1,
+    frequency: 1,
     category: "animales",
     structure: "CV-CV",
     image: null
@@ -43,6 +46,7 @@ export const level1Animals = [
     initialSyllable: "sa",
     finalSyllable: "po",
     difficulty: 1,
+    frequency: 2,
     category: "animales",
     structure: "CV-CV",
     image: null
@@ -55,6 +59,7 @@ export const level1Animals = [
     initialSyllable: "lo",
     finalSyllable: "bo",
     difficulty: 1,
+    frequency: 2,
     category: "animales",
     structure: "CV-CV",
     image: null
@@ -67,6 +72,7 @@ export const level1Animals = [
     initialSyllable: "va",
     finalSyllable: "ca",
     difficulty: 1,
+    frequency: 1,
     category: "animales",
     structure: "CV-CV",
     image: null
@@ -79,6 +85,7 @@ export const level1Animals = [
     initialSyllable: "fo",
     finalSyllable: "ca",
     difficulty: 1,
+    frequency: 2,
     category: "animales",
     structure: "CV-CV",
     image: null
@@ -91,6 +98,7 @@ export const level1Animals = [
     initialSyllable: "ra",
     finalSyllable: "na",
     difficulty: 1,
+    frequency: 1,
     category: "animales",
     structure: "CV-CV",
     image: null
@@ -103,6 +111,7 @@ export const level1Animals = [
     initialSyllable: "pu",
     finalSyllable: "ma",
     difficulty: 1,
+    frequency: 3,
     category: "animales",
     structure: "CV-CV",
     image: null
@@ -115,6 +124,7 @@ export const level1Animals = [
     initialSyllable: "fo",
     finalSyllable: "ca",
     difficulty: 1,
+    frequency: 2,
     category: "animales",
     structure: "CV-CV",
     image: null
@@ -128,6 +138,7 @@ export const level1Animals = [
     initialSyllable: "co",
     finalSyllable: "jo",
     difficulty: 1,
+    frequency: 2,
     category: "animales",
     structure: "CV-CV-CV",
     image: null
@@ -140,6 +151,7 @@ export const level1Animals = [
     initialSyllable: "o",
     finalSyllable: "ja",
     difficulty: 1,
+    frequency: 2,
     category: "animales",
     structure: "V-CV-CV",
     image: null
@@ -152,6 +164,7 @@ export const level1Animals = [
     initialSyllable: "ba",
     finalSyllable: "na",
     difficulty: 1,
+    frequency: 3,
     category: "animales",
     structure: "CV-CV-CV",
     image: null
@@ -164,6 +177,7 @@ export const level1Animals = [
     initialSyllable: "ma",
     finalSyllable: "sa",
     difficulty: 1,
+    frequency: 2,
     category: "animales",
     structure: "CV-CV-CV-CV",
     image: null
@@ -176,6 +190,7 @@ export const level1Animals = [
     initialSyllable: "gu",
     finalSyllable: "no",
     difficulty: 1,
+    frequency: 2,
     category: "animales",
     structure: "CV-CV-CV",
     image: null
@@ -188,6 +203,7 @@ export const level1Animals = [
     initialSyllable: "pa",
     finalSyllable: "ma",
     difficulty: 1,
+    frequency: 2,
     category: "animales",
     structure: "CV-CV-CV",
     image: null
@@ -200,6 +216,7 @@ export const level1Animals = [
     initialSyllable: "tor",
     finalSyllable: "ga",
     difficulty: 1,
+    frequency: 3,
     category: "animales",
     structure: "CVC-CV-CV",
     image: null
@@ -212,6 +229,7 @@ export const level1Animals = [
     initialSyllable: "ca",
     finalSyllable: "llo",
     difficulty: 1,
+    frequency: 3,
     category: "animales",
     structure: "CV-CV-CV",
     image: null
@@ -224,6 +242,7 @@ export const level1Animals = [
     initialSyllable: "po",
     finalSyllable: "to",
     difficulty: 1,
+    frequency: 2,
     category: "animales",
     structure: "CV-CV-CV",
     image: null
@@ -236,6 +255,7 @@ export const level1Animals = [
     initialSyllable: "a",
     finalSyllable: "ja",
     difficulty: 1,
+    frequency: 2,
     category: "animales",
     structure: "V-CV-CV",
     image: null
@@ -249,6 +269,7 @@ export const level1Animals = [
     initialSyllable: "bu",
     finalSyllable: "rro",
     difficulty: 1,
+    frequency: 2,
     category: "animales",
     structure: "CV-CV",
     image: null
@@ -261,6 +282,7 @@ export const level1Animals = [
     initialSyllable: "ce",
     finalSyllable: "bra",
     difficulty: 1,
+    frequency: 3,
     category: "animales",
     structure: "CV-CCV",
     image: null
@@ -273,6 +295,7 @@ export const level1Animals = [
     initialSyllable: "ti",
     finalSyllable: "gre",
     difficulty: 1,
+    frequency: 3,
     category: "animales",
     structure: "CV-CCV",
     image: null
@@ -285,6 +308,7 @@ export const level1Animals = [
     initialSyllable: "le",
     finalSyllable: "ón",
     difficulty: 1,
+    frequency: 2,
     category: "animales",
     structure: "CV-VC",
     image: null
@@ -297,6 +321,7 @@ export const level1Animals = [
     initialSyllable: "ra",
     finalSyllable: "tón",
     difficulty: 1,
+    frequency: 1,
     category: "animales",
     structure: "CV-CVC",
     image: null

--- a/src/data/words/food.js
+++ b/src/data/words/food.js
@@ -7,6 +7,7 @@ export const level1Food = [
     initialSyllable: "so",
     finalSyllable: "pa",
     difficulty: 1,
+    frequency: 1,
     category: "comida",
     structure: "CV-CV",
     image: null
@@ -19,6 +20,7 @@ export const level1Food = [
     initialSyllable: "pa",
     finalSyllable: "pa",
     difficulty: 1,
+    frequency: 1,
     category: "comida",
     structure: "CV-CV",
     image: null
@@ -31,6 +33,7 @@ export const level1Food = [
     initialSyllable: "que",
     finalSyllable: "so",
     difficulty: 1,
+    frequency: 1,
     category: "comida",
     structure: "CV-CV",
     image: null
@@ -43,6 +46,7 @@ export const level1Food = [
     initialSyllable: "man",
     finalSyllable: "go",
     difficulty: 1,
+    frequency: 2,
     category: "comida",
     structure: "CVC-CV",
     image: null
@@ -55,6 +59,7 @@ export const level1Food = [
     initialSyllable: "me",
     finalSyllable: "lón",
     difficulty: 1,
+    frequency: 2,
     category: "comida",
     structure: "CV-CVC",
     image: null
@@ -68,6 +73,7 @@ export const level1Food = [
     initialSyllable: "tar",
     finalSyllable: "ta",
     difficulty: 1,
+    frequency: 2,
     category: "comida",
     structure: "CVC-CV",
     image: null
@@ -80,6 +86,7 @@ export const level1Food = [
     initialSyllable: "ga",
     finalSyllable: "ta",
     difficulty: 1,
+    frequency: 1,
     category: "comida",
     structure: "CV-CV-CV",
     image: null
@@ -92,6 +99,7 @@ export const level1Food = [
     initialSyllable: "to",
     finalSyllable: "te",
     difficulty: 1,
+    frequency: 1,
     category: "comida",
     structure: "CV-CV-CV",
     image: null
@@ -104,6 +112,7 @@ export const level1Food = [
     initialSyllable: "pa",
     finalSyllable: "ta",
     difficulty: 1,
+    frequency: 2,
     category: "comida",
     structure: "CV-CV-CV",
     image: null
@@ -116,6 +125,7 @@ export const level1Food = [
     initialSyllable: "gui",
     finalSyllable: "so",
     difficulty: 1,
+    frequency: 3,
     category: "comida",
     structure: "CVV-CV",
     image: null
@@ -129,6 +139,7 @@ export const level1Food = [
     initialSyllable: "fre",
     finalSyllable: "sa",
     difficulty: 1,
+    frequency: 2,
     category: "comida",
     structure: "CCV-CV",
     image: null
@@ -141,6 +152,7 @@ export const level1Food = [
     initialSyllable: "plá",
     finalSyllable: "no",
     difficulty: 1,
+    frequency: 2,
     category: "comida",
     structure: "CCV-CV-CV",
     image: null
@@ -153,6 +165,7 @@ export const level1Food = [
     initialSyllable: "na",
     finalSyllable: "ja",
     difficulty: 1,
+    frequency: 1,
     category: "comida",
     structure: "CV-CVC-CV",
     image: null
@@ -165,6 +178,7 @@ export const level1Food = [
     initialSyllable: "man",
     finalSyllable: "na",
     difficulty: 1,
+    frequency: 1,
     category: "comida",
     structure: "CVC-CV-CV",
     image: null
@@ -177,6 +191,7 @@ export const level1Food = [
     initialSyllable: "pe",
     finalSyllable: "ra",
     difficulty: 1,
+    frequency: 1,
     category: "comida",
     structure: "CV-CV",
     image: null
@@ -190,6 +205,7 @@ export const level1Food = [
     initialSyllable: "ki",
     finalSyllable: "wi",
     difficulty: 1,
+    frequency: 2,
     category: "comida",
     structure: "CV-CV",
     image: null
@@ -202,6 +218,7 @@ export const level1Food = [
     initialSyllable: "li",
     finalSyllable: "món",
     difficulty: 1,
+    frequency: 2,
     category: "comida",
     structure: "CV-CVC",
     image: null
@@ -214,6 +231,7 @@ export const level1Food = [
     initialSyllable: "ha",
     finalSyllable: "na",
     difficulty: 1,
+    frequency: 3,
     category: "comida",
     structure: "CV-CV-CV",
     image: null
@@ -226,6 +244,7 @@ export const level1Food = [
     initialSyllable: "ga",
     finalSyllable: "ta",
     difficulty: 1,
+    frequency: 1,
     category: "comida",
     structure: "CV-CV-CV",
     image: null
@@ -238,6 +257,7 @@ export const level1Food = [
     initialSyllable: "chu",
     finalSyllable: "rro",
     difficulty: 1,
+    frequency: 2,
     category: "comida",
     structure: "CV-CV",
     image: null
@@ -251,6 +271,7 @@ export const level1Food = [
     initialSyllable: "pes",
     finalSyllable: "do",
     difficulty: 1,
+    frequency: 2,
     category: "comida",
     structure: "CVC-CV-CV",
     image: null
@@ -263,6 +284,7 @@ export const level1Food = [
     initialSyllable: "yo",
     finalSyllable: "gur",
     difficulty: 1,
+    frequency: 2,
     category: "comida",
     structure: "CV-CVC",
     image: null
@@ -275,6 +297,7 @@ export const level1Food = [
     initialSyllable: "he",
     finalSyllable: "do",
     difficulty: 1,
+    frequency: 1,
     category: "comida",
     structure: "CV-CV-CV",
     image: null
@@ -287,6 +310,7 @@ export const level1Food = [
     initialSyllable: "pan",
     finalSyllable: "pan",
     difficulty: 1,
+    frequency: 1,
     category: "comida",
     structure: "CVC",
     image: null
@@ -299,6 +323,7 @@ export const level1Food = [
     initialSyllable: "a",
     finalSyllable: "rroz",
     difficulty: 1,
+    frequency: 1,
     category: "comida",
     structure: "V-CCVC",
     image: null

--- a/src/data/words/home.js
+++ b/src/data/words/home.js
@@ -7,6 +7,7 @@ export const level1Home = [
     initialSyllable: "ca",
     finalSyllable: "sa",
     difficulty: 1,
+    frequency: 1,
     category: "hogar",
     structure: "CV-CV",
     image: null
@@ -19,6 +20,7 @@ export const level1Home = [
     initialSyllable: "me",
     finalSyllable: "sa",
     difficulty: 1,
+    frequency: 1,
     category: "hogar",
     structure: "CV-CV",
     image: null
@@ -31,6 +33,7 @@ export const level1Home = [
     initialSyllable: "ca",
     finalSyllable: "ma",
     difficulty: 1,
+    frequency: 1,
     category: "hogar",
     structure: "CV-CV",
     image: null
@@ -43,6 +46,7 @@ export const level1Home = [
     initialSyllable: "si",
     finalSyllable: "lla",
     difficulty: 1,
+    frequency: 1,
     category: "hogar",
     structure: "CV-CV",
     image: null
@@ -55,6 +59,7 @@ export const level1Home = [
     initialSyllable: "ta",
     finalSyllable: "za",
     difficulty: 1,
+    frequency: 1,
     category: "hogar",
     structure: "CV-CV",
     image: null
@@ -68,6 +73,7 @@ export const level1Home = [
     initialSyllable: "ca",
     finalSyllable: "ja",
     difficulty: 1,
+    frequency: 1,
     category: "hogar",
     structure: "CV-CV",
     image: null
@@ -80,6 +86,7 @@ export const level1Home = [
     initialSyllable: "puer",
     finalSyllable: "ta",
     difficulty: 1,
+    frequency: 1,
     category: "hogar",
     structure: "CVVC-CV",
     image: null
@@ -92,6 +99,7 @@ export const level1Home = [
     initialSyllable: "te",
     finalSyllable: "cho",
     difficulty: 1,
+    frequency: 2,
     category: "hogar",
     structure: "CV-CV",
     image: null
@@ -104,6 +112,7 @@ export const level1Home = [
     initialSyllable: "sue",
     finalSyllable: "lo",
     difficulty: 1,
+    frequency: 2,
     category: "hogar",
     structure: "CVV-CV",
     image: null
@@ -116,6 +125,7 @@ export const level1Home = [
     initialSyllable: "lám",
     finalSyllable: "ra",
     difficulty: 1,
+    frequency: 2,
     category: "hogar",
     structure: "CVC-CV-CV",
     image: null
@@ -129,6 +139,7 @@ export const level1Home = [
     initialSyllable: "ven",
     finalSyllable: "na",
     difficulty: 1,
+    frequency: 2,
     category: "hogar",
     structure: "CVC-CV-CV",
     image: null
@@ -141,6 +152,7 @@ export const level1Home = [
     initialSyllable: "co",
     finalSyllable: "na",
     difficulty: 1,
+    frequency: 1,
     category: "hogar",
     structure: "CV-CV-CV",
     image: null
@@ -153,6 +165,7 @@ export const level1Home = [
     initialSyllable: "cor",
     finalSyllable: "na",
     difficulty: 1,
+    frequency: 2,
     category: "hogar",
     structure: "CVC-CV-CV",
     image: null
@@ -165,6 +178,7 @@ export const level1Home = [
     initialSyllable: "ar",
     finalSyllable: "rio",
     difficulty: 1,
+    frequency: 2,
     category: "hogar",
     structure: "VC-CV-CVV",
     image: null
@@ -177,6 +191,7 @@ export const level1Home = [
     initialSyllable: "es",
     finalSyllable: "jo",
     difficulty: 1,
+    frequency: 2,
     category: "hogar",
     structure: "VC-CV-CV",
     image: null
@@ -190,6 +205,7 @@ export const level1Home = [
     initialSyllable: "al",
     finalSyllable: "bra",
     difficulty: 1,
+    frequency: 3,
     category: "hogar",
     structure: "VC-CVC-CCV",
     image: null
@@ -202,6 +218,7 @@ export const level1Home = [
     initialSyllable: "co",
     finalSyllable: "jín",
     difficulty: 1,
+    frequency: 2,
     category: "hogar",
     structure: "CV-CVC",
     image: null
@@ -214,6 +231,7 @@ export const level1Home = [
     initialSyllable: "sá",
     finalSyllable: "na",
     difficulty: 1,
+    frequency: 2,
     category: "hogar",
     structure: "CV-CV-CV",
     image: null
@@ -226,6 +244,7 @@ export const level1Home = [
     initialSyllable: "to",
     finalSyllable: "lla",
     difficulty: 1,
+    frequency: 2,
     category: "hogar",
     structure: "CV-V-CV",
     image: null
@@ -238,6 +257,7 @@ export const level1Home = [
     initialSyllable: "ja",
     finalSyllable: "bón",
     difficulty: 1,
+    frequency: 1,
     category: "hogar",
     structure: "CV-CVC",
     image: null
@@ -251,6 +271,7 @@ export const level1Home = [
     initialSyllable: "ba",
     finalSyllable: "ra",
     difficulty: 1,
+    frequency: 2,
     category: "hogar",
     structure: "CV-CV-CV",
     image: null
@@ -263,6 +284,7 @@ export const level1Home = [
     initialSyllable: "es",
     finalSyllable: "fa",
     difficulty: 1,
+    frequency: 3,
     category: "hogar",
     structure: "VC-CV-CV",
     image: null
@@ -275,6 +297,7 @@ export const level1Home = [
     initialSyllable: "ce",
     finalSyllable: "llo",
     difficulty: 1,
+    frequency: 2,
     category: "hogar",
     structure: "CV-CV-CV",
     image: null
@@ -287,6 +310,7 @@ export const level1Home = [
     initialSyllable: "cu",
     finalSyllable: "ra",
     difficulty: 1,
+    frequency: 2,
     category: "hogar",
     structure: "CV-CV-CV",
     image: null
@@ -299,6 +323,7 @@ export const level1Home = [
     initialSyllable: "te",
     finalSyllable: "dor",
     difficulty: 1,
+    frequency: 2,
     category: "hogar",
     structure: "CV-CV-CVC",
     image: null


### PR DESCRIPTION
### Motivation
- Añadir un campo `frequency` a todo el dataset para permitir clasificar palabras por frecuencia/familiaridad infantil según la escala provista (1–3).
- Mantener exactamente la estructura y formato existentes de los objetos del dataset y no tocar otros campos ni imports/exports. 

### Description
- Inserté el campo `frequency` en cada objeto de `src/data/words/animals.js`, `src/data/words/food.js` y `src/data/words/home.js` colocándolo inmediatamente después de `difficulty` para mantener la consistencia de formato. 
- Asigné valores `1`, `2` o `3` siguiendo la escala especificada, priorizando la frecuencia y familiaridad infantil (no la dificultad lingüística). 
- No modifiqué ningún otro campo, ni cambié imports/exports ni la estructura de los arrays; los cambios son solo la adición de `frequency` en cada entrada. 

### Testing
- Ejecuté el script de actualización que inserta `frequency` en cada archivo del dataset (operación automatizada); el script finalizó con éxito. 
- Verifiqué cobertura comparando el recuento de `difficulty` y `frequency` por archivo con el comando `for f in src/data/words/animals.js src/data/words/food.js src/data/words/home.js; do rg -o "difficulty:" $f | wc -l; rg -o "frequency:" $f | wc -l; done` y los conteos coincidieron en cada archivo. 
- Hice comprobaciones puntuales listando ubicaciones de `frequency` con `rg -n "frequency:" src/data/words/*.js` para confirmar inserciones; las comprobaciones automatizadas pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd9dc9bd34832d9522bfaa58bf03c4)