### PR TITLE
Añade portada principal con navegación y sílabas en mayúsculas

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,44 +3,62 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Ordenar sílabas</title>
+  <title>TITULO</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <div class="app">
-    <header class="app-header panel">
-      <p class="eyebrow">Ejercicio base de plataforma</p>
-      <h1>Ordenar sílabas</h1>
-      <p class="subtitle">Toca las sílabas en orden para construir la palabra.</p>
-    </header>
+    <section id="home-screen" class="panel home-screen">
+      <p class="eyebrow">Plataforma educativa</p>
+      <h1>TITULO</h1>
+      <p class="subtitle">Una experiencia interactiva para practicar habilidades lingüísticas con ejercicios breves, claros y progresivos.</p>
 
-    <main class="panel exercise-panel">
-      <div class="exercise-top">
-        <div>
-          <p class="eyebrow" id="level-label">Nivel 1</p>
-          <h2 id="round-word">2 sílabas</h2>
+      <nav class="exercise-menu" aria-label="Menú de ejercicios">
+        <button type="button" class="exercise-card" data-exercise="order-syllables">
+          <strong>Ordenar sílabas</strong>
+          <span>Organiza sílabas para formar palabras correctamente.</span>
+        </button>
+      </nav>
+    </section>
+
+    <section id="exercise-screen" class="exercise-screen is-hidden">
+      <header class="app-header panel">
+        <div class="header-top-row">
+          <button id="home-btn" class="back-btn" type="button" aria-label="Volver a la portada">Inicio</button>
+          <p class="eyebrow">Ejercicio base de plataforma</p>
+        </div>
+        <h1>Ordenar sílabas</h1>
+        <p class="subtitle">Toca las sílabas en orden para construir la palabra.</p>
+      </header>
+
+      <main class="panel exercise-panel">
+        <div class="exercise-top">
+          <div>
+            <p class="eyebrow" id="level-label">Nivel 1</p>
+            <h2 id="round-word">2 sílabas</h2>
+          </div>
+
+          <div class="score-box">
+            <span>Aciertos</span>
+            <strong id="score">0</strong>
+          </div>
         </div>
 
-        <div class="score-box">
-          <span>Aciertos</span>
-          <strong id="score">0</strong>
+        <div class="level-tabs">
+          <button class="level-btn is-active" data-level="1">Nivel 1</button>
+          <button class="level-btn" data-level="2">Nivel 2</button>
+          <button class="level-btn" data-level="3">Nivel 3</button>
         </div>
-      </div>
 
-      <div class="level-tabs">
-        <button class="level-btn is-active" data-level="1">Nivel 1</button>
-        <button class="level-btn" data-level="2">Nivel 2</button>
-        <button class="level-btn" data-level="3">Nivel 3</button>
-      </div>
+        <div id="exercise-container" class="exercise-container"></div>
 
-      <div id="exercise-container" class="exercise-container"></div>
+        <div class="actions">
+          <button id="next-btn" class="secondary-btn">Nueva palabra</button>
+        </div>
 
-      <div class="actions">
-        <button id="next-btn" class="secondary-btn">Nueva palabra</button>
-      </div>
-
-      <p id="feedback" class="feedback" aria-live="polite"></p>
-    </main>
+        <p id="feedback" class="feedback" aria-live="polite"></p>
+      </main>
+    </section>
   </div>
 
   <script type="module" src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -1,8 +1,13 @@
 import { validateWords } from './src/core/validateWords.js';
 import { WORDS } from './src/data/words/index.js';
 import { createOrderSyllablesRound } from './src/exercises/orderSyllables.js';
+import { createHomeController } from './src/ui/home.js';
+import { createRouter } from './src/navigation/router.js';
 
 const refs = {
+  homeScreen: document.querySelector('#home-screen'),
+  exerciseScreen: document.querySelector('#exercise-screen'),
+  homeBtn: document.querySelector('#home-btn'),
   levelButtons: document.querySelectorAll('.level-btn'),
   exerciseContainer: document.querySelector('#exercise-container'),
   feedback: document.querySelector('#feedback'),
@@ -24,6 +29,11 @@ const POSITION_PATTERNS = {
   3: ['slot-a', 'slot-c', 'slot-e'],
   4: ['slot-a', 'slot-b', 'slot-d', 'slot-f']
 };
+
+const router = createRouter({
+  homeScreen: refs.homeScreen,
+  exerciseScreen: refs.exerciseScreen
+});
 
 function setFeedback(message, type = '') {
   refs.feedback.textContent = message;
@@ -55,7 +65,7 @@ function renderRound() {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = `syllable-piece ${slots[index] ?? 'slot-c'}`;
-    button.textContent = piece.text;
+    button.textContent = piece.text.toUpperCase();
     button.dataset.syllable = piece.text;
     button.addEventListener('click', () => handleSyllableTap(button));
     piecesWrap.appendChild(button);
@@ -85,7 +95,7 @@ function updateAnswerSlots() {
   const slots = refs.exerciseContainer.querySelectorAll('.answer-slot');
 
   slots.forEach((slot, index) => {
-    slot.textContent = state.answer[index] ?? '';
+    slot.textContent = state.answer[index]?.toUpperCase() ?? '';
   });
 }
 
@@ -147,15 +157,35 @@ function setLevel(level) {
   startRound();
 }
 
+function openExercise(exerciseId) {
+  if (exerciseId !== 'order-syllables') {
+    return;
+  }
+
+  router.showExercise();
+  state.score = 0;
+  refs.score.textContent = '0';
+  setLevel(1);
+}
+
 function init() {
   validateWords(WORDS);
+
+  const homeController = createHomeController({
+    homeScreen: refs.homeScreen,
+    onSelectExercise: openExercise
+  });
+
+  homeController.bindEvents();
 
   refs.levelButtons.forEach((button) => {
     button.addEventListener('click', () => setLevel(Number(button.dataset.level)));
   });
 
   refs.nextBtn.addEventListener('click', startRound);
-  setLevel(1);
+  refs.homeBtn.addEventListener('click', () => router.showHome());
+
+  router.showHome();
 }
 
 init();

--- a/src/navigation/router.js
+++ b/src/navigation/router.js
@@ -1,0 +1,17 @@
+const SCREENS = {
+  home: 'home',
+  exercise: 'exercise'
+};
+
+export function createRouter({ homeScreen, exerciseScreen }) {
+  function show(screen) {
+    const showHome = screen === SCREENS.home;
+    homeScreen.classList.toggle('is-hidden', !showHome);
+    exerciseScreen.classList.toggle('is-hidden', showHome);
+  }
+
+  return {
+    showHome: () => show(SCREENS.home),
+    showExercise: () => show(SCREENS.exercise)
+  };
+}

--- a/src/ui/home.js
+++ b/src/ui/home.js
@@ -1,0 +1,14 @@
+export function createHomeController({ homeScreen, onSelectExercise }) {
+  const cards = homeScreen.querySelectorAll('[data-exercise]');
+
+  function bindEvents() {
+    cards.forEach((card) => {
+      card.addEventListener('click', () => {
+        const exerciseId = card.dataset.exercise;
+        onSelectExercise(exerciseId);
+      });
+    });
+  }
+
+  return { bindEvents };
+}

--- a/style.css
+++ b/style.css
@@ -17,6 +17,27 @@ body { margin:0; font-family: system-ui,sans-serif; background: linear-gradient(
 .eyebrow { margin:0 0 6px; font-size:.8rem; text-transform:uppercase; letter-spacing:.1em; color:var(--muted); font-weight:800; }
 h1,h2 { margin:0; }
 .subtitle { margin:8px 0 0; color:var(--muted); }
+.is-hidden { display: none; }
+
+.home-screen { display: grid; gap: 18px; }
+.exercise-menu { display: grid; gap: 10px; }
+.exercise-card {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: #fff;
+  padding: 14px 16px;
+  text-align: left;
+  display: grid;
+  gap: 4px;
+}
+.exercise-card strong { font-size: 1rem; }
+.exercise-card span { color: var(--muted); font-size: .92rem; }
+
+.exercise-screen { display: grid; gap: 16px; }
+.header-top-row { display: flex; align-items: center; gap: 10px; margin-bottom: 4px; }
+.back-btn { border:1px solid var(--line); background:#fff; border-radius:999px; min-height:38px; padding:0 14px; font-weight:700; }
+
 .exercise-top { display:flex; justify-content:space-between; align-items:center; }
 .score-box { background:var(--surface-soft); border-radius:14px; padding:8px 14px; text-align:center; }
 .level-tabs { display:flex; gap:8px; margin:18px 0; flex-wrap:wrap; }
@@ -51,4 +72,7 @@ h1,h2 { margin:0; }
 .feedback.is-error { color:var(--error); }
 @keyframes shake { 25%{transform:translateX(-4px)} 50%{transform:translateX(4px)} 100%{transform:translateX(0)} }
 @keyframes pulse { 50%{transform:scale(1.04)} }
-@media (max-width: 640px) { .syllable-piece { min-width:72px; font-size:1.05rem; } }
+@media (max-width: 640px) {
+  .syllable-piece { min-width:72px; font-size:1.05rem; }
+  .panel { padding: 16px; }
+}


### PR DESCRIPTION
### Motivation
- Añadir una portada (Home) para que la app se perciba como plataforma y no entre directamente al ejercicio.
- Mantener la arquitectura modular y preparada para añadir nuevos ejercicios sin mezclar responsabilidades.
- Mejorar la legibilidad del ejercicio actual haciendo que las sílabas se muestren siempre en MAYÚSCULAS de forma visual sin tocar el dataset ni la lógica.

### Description
- Se separan las vistas en `home-screen` y `exercise-screen` en `index.html` y se introduce un menú visual de ejercicios con una tarjeta para `order-syllables`.
- Se añade `src/ui/home.js` como controlador del menú y `src/navigation/router.js` como router simple que muestra/oculta pantallas y se integran desde `main.js`.
- En `main.js` se integra la navegación Home→Ejercicio→Home, se reinicia `score` al abrir el ejercicio y se aplica `toUpperCase()` al renderizar las piezas y los slots de respuesta sin modificar los datos originales ni la validación.
- Se actualiza `style.css` para estilos de portada, tarjetas de ejercicios, botón de regreso y ajustes responsive para móvil/tablet.

### Testing
- No se ejecutaron pruebas automatizadas en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdbc5bda48832daf19ad861d5976fb)