### PR TITLE
Separar UI en vistas: Home y Exercise

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,25 +7,40 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="app">
-    <section id="home-screen" class="panel home-screen">
-      <p class="eyebrow">Plataforma educativa</p>
-      <h1>TITULO</h1>
-      <p class="subtitle">Una experiencia interactiva para practicar habilidades lingüísticas con ejercicios breves, claros y progresivos.</p>
+  <div class="app-shell">
+    <section id="home-screen" class="view home-view" data-view="home">
+      <div class="panel home-hero">
+        <p class="eyebrow">Plataforma educativa</p>
+        <h1>TITULO</h1>
+        <p class="subtitle">Practica habilidades lingüísticas con ejercicios cortos, progresivos y diseñados para una experiencia clara en móvil y escritorio.</p>
+      </div>
 
-      <nav class="exercise-menu" aria-label="Menú de ejercicios">
-        <button type="button" class="exercise-card" data-exercise="order-syllables">
-          <strong>Ordenar sílabas</strong>
-          <span>Organiza sílabas para formar palabras correctamente.</span>
-        </button>
-      </nav>
+      <div class="panel">
+        <h2 class="menu-title">Ejercicios</h2>
+        <nav class="exercise-menu" aria-label="Menú de ejercicios">
+          <button type="button" class="exercise-card" data-exercise="order-syllables" data-available="true">
+            <strong>Ordenar sílabas</strong>
+            <span>Organiza sílabas para formar palabras correctamente.</span>
+          </button>
+
+          <button type="button" class="exercise-card is-disabled" data-exercise="intruder-syllables" data-available="false">
+            <strong>Intruso silábico</strong>
+            <span>Próximamente</span>
+          </button>
+
+          <button type="button" class="exercise-card is-disabled" data-exercise="memory" data-available="false">
+            <strong>Memoria</strong>
+            <span>Próximamente</span>
+          </button>
+        </nav>
+      </div>
     </section>
 
-    <section id="exercise-screen" class="exercise-screen is-hidden">
-      <header class="app-header panel">
+    <section id="exercise-screen" class="view exercise-view" data-view="exercise" hidden>
+      <header class="panel app-header">
         <div class="header-top-row">
-          <button id="home-btn" class="back-btn" type="button" aria-label="Volver a la portada">Inicio</button>
-          <p class="eyebrow">Ejercicio base de plataforma</p>
+          <button id="home-btn" class="back-btn" type="button" aria-label="Volver a inicio">← Inicio</button>
+          <p class="eyebrow">Ejercicio</p>
         </div>
         <h1>Ordenar sílabas</h1>
         <p class="subtitle">Toca las sílabas en orden para construir la palabra.</p>

--- a/main.js
+++ b/main.js
@@ -31,8 +31,10 @@ const POSITION_PATTERNS = {
 };
 
 const router = createRouter({
-  homeScreen: refs.homeScreen,
-  exerciseScreen: refs.exerciseScreen
+  views: {
+    home: refs.homeScreen,
+    exercise: refs.exerciseScreen
+  }
 });
 
 function setFeedback(message, type = '') {

--- a/src/navigation/router.js
+++ b/src/navigation/router.js
@@ -1,17 +1,36 @@
-const SCREENS = {
+const VIEWS = {
   home: 'home',
   exercise: 'exercise'
 };
 
-export function createRouter({ homeScreen, exerciseScreen }) {
-  function show(screen) {
-    const showHome = screen === SCREENS.home;
-    homeScreen.classList.toggle('is-hidden', !showHome);
-    exerciseScreen.classList.toggle('is-hidden', showHome);
+export function createRouter({ views, initialView = VIEWS.home }) {
+  let currentView = initialView;
+
+  function render(view) {
+    currentView = view;
+
+    Object.entries(views).forEach(([viewId, node]) => {
+      const isActive = viewId === view;
+      node.hidden = !isActive;
+      node.classList.toggle('is-active-view', isActive);
+    });
   }
 
+  function goTo(view) {
+    if (!views[view]) {
+      return;
+    }
+
+    render(view);
+  }
+
+  render(initialView);
+
   return {
-    showHome: () => show(SCREENS.home),
-    showExercise: () => show(SCREENS.exercise)
+    goTo,
+    showHome: () => goTo(VIEWS.home),
+    showExercise: () => goTo(VIEWS.exercise),
+    getCurrentView: () => currentView,
+    views: VIEWS
   };
 }

--- a/src/ui/home.js
+++ b/src/ui/home.js
@@ -3,6 +3,13 @@ export function createHomeController({ homeScreen, onSelectExercise }) {
 
   function bindEvents() {
     cards.forEach((card) => {
+      const isAvailable = card.dataset.available === 'true';
+
+      if (!isAvailable) {
+        card.setAttribute('aria-disabled', 'true');
+        return;
+      }
+
       card.addEventListener('click', () => {
         const exerciseId = card.dataset.exercise;
         onSelectExercise(exerciseId);

--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 :root {
-  --bg: #f7f4ef;
+  --bg: #f5f2ec;
   --surface: #ffffff;
   --surface-soft: #f2ece4;
   --text: #241f1b;
@@ -10,16 +10,47 @@
   --line: rgba(60, 42, 30, 0.14);
   --radius: 18px;
 }
-* { box-sizing: border-box; }
-body { margin:0; font-family: system-ui,sans-serif; background: linear-gradient(180deg,#f8f5f0,#eee6dc); color:var(--text); }
-.app { width:min(100% - 24px,860px); margin:24px auto; display:grid; gap:16px; }
-.panel { background:rgba(255,255,255,.86); border:1px solid var(--line); border-radius:24px; padding:20px; }
-.eyebrow { margin:0 0 6px; font-size:.8rem; text-transform:uppercase; letter-spacing:.1em; color:var(--muted); font-weight:800; }
-h1,h2 { margin:0; }
-.subtitle { margin:8px 0 0; color:var(--muted); }
-.is-hidden { display: none; }
 
-.home-screen { display: grid; gap: 18px; }
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: linear-gradient(180deg, #f8f5f0, #eee6dc);
+  color: var(--text);
+}
+
+.app-shell {
+  width: min(100% - 24px, 920px);
+  margin: 20px auto;
+}
+
+.view {
+  display: grid;
+  gap: 16px;
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  padding: 20px;
+  box-shadow: 0 8px 24px rgba(36, 31, 27, 0.05);
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  font-size: .8rem;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  color: var(--muted);
+  font-weight: 800;
+}
+
+h1, h2 { margin: 0; }
+.subtitle { margin: 8px 0 0; color: var(--muted); }
+.menu-title { margin: 0 0 12px; }
+
 .exercise-menu { display: grid; gap: 10px; }
 .exercise-card {
   width: 100%;
@@ -33,27 +64,36 @@ h1,h2 { margin:0; }
 }
 .exercise-card strong { font-size: 1rem; }
 .exercise-card span { color: var(--muted); font-size: .92rem; }
+.exercise-card:not(.is-disabled) { cursor: pointer; }
+.exercise-card.is-disabled { opacity: .65; }
 
-.exercise-screen { display: grid; gap: 16px; }
 .header-top-row { display: flex; align-items: center; gap: 10px; margin-bottom: 4px; }
-.back-btn { border:1px solid var(--line); background:#fff; border-radius:999px; min-height:38px; padding:0 14px; font-weight:700; }
+.back-btn { border: 1px solid var(--line); background: #fff; border-radius: 999px; min-height: 38px; padding: 0 14px; font-weight: 700; }
 
-.exercise-top { display:flex; justify-content:space-between; align-items:center; }
-.score-box { background:var(--surface-soft); border-radius:14px; padding:8px 14px; text-align:center; }
-.level-tabs { display:flex; gap:8px; margin:18px 0; flex-wrap:wrap; }
-.level-btn,.secondary-btn { border:1px solid var(--line); background:#fff; border-radius:999px; min-height:44px; padding:0 16px; font-weight:700; }
-.level-btn.is-active { background:var(--accent); color:#fff; }
-.exercise-container { display:grid; gap:18px; }
+.exercise-top { display: flex; justify-content: space-between; align-items: center; }
+.score-box { background: var(--surface-soft); border-radius: 14px; padding: 8px 14px; text-align: center; }
+.level-tabs { display: flex; gap: 8px; margin: 18px 0; flex-wrap: wrap; }
+.level-btn, .secondary-btn { border: 1px solid var(--line); background: #fff; border-radius: 999px; min-height: 44px; padding: 0 16px; font-weight: 700; }
+.level-btn.is-active { background: var(--accent); color: #fff; }
+
+.exercise-container { display: grid; gap: 18px; }
 .pieces-cloud {
   position: relative;
   min-height: 230px;
   border: 1px dashed var(--line);
   border-radius: 22px;
-  background: rgba(255,255,255,.6);
+  background: rgba(255, 255, 255, .6);
 }
 .syllable-piece {
-  position:absolute; min-width:88px; padding:14px 18px; border-radius:16px; border:1px solid var(--line);
-  background:#fff; font-size:1.25rem; font-weight:800;
+  position: absolute;
+  min-width: 88px;
+  padding: 14px 18px;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background: #fff;
+  font-size: 1.25rem;
+  font-weight: 800;
+  text-transform: uppercase;
 }
 .slot-a { top: 14%; left: 10%; }
 .slot-b { top: 12%; left: 34%; }
@@ -63,16 +103,31 @@ h1,h2 { margin:0; }
 .slot-f { top: 60%; left: 10%; }
 .syllable-piece.is-correct { animation: pulse .26s ease; }
 .syllable-piece.is-wrong { animation: shake .24s ease; border-color: var(--error); color: var(--error); }
-.answer-zone { background:var(--surface-soft); border-radius:18px; padding:14px; }
-.answer-zone__label { margin:0 0 10px; font-weight:700; color:var(--muted); }
-.answer-slots { display:flex; gap:10px; flex-wrap:wrap; }
-.answer-slot { min-width:74px; min-height:56px; display:grid; place-items:center; background:#fff; border:1px solid var(--line); border-radius:14px; font-size:1.1rem; font-weight:800; }
-.feedback { min-height:24px; margin:12px 0 0; font-weight:700; }
-.feedback.is-success { color:var(--success); }
-.feedback.is-error { color:var(--error); }
-@keyframes shake { 25%{transform:translateX(-4px)} 50%{transform:translateX(4px)} 100%{transform:translateX(0)} }
-@keyframes pulse { 50%{transform:scale(1.04)} }
+
+.answer-zone { background: var(--surface-soft); border-radius: 18px; padding: 14px; }
+.answer-zone__label { margin: 0 0 10px; font-weight: 700; color: var(--muted); }
+.answer-slots { display: flex; gap: 10px; flex-wrap: wrap; }
+.answer-slot {
+  min-width: 74px;
+  min-height: 56px;
+  display: grid;
+  place-items: center;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  font-size: 1.1rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.feedback { min-height: 24px; margin: 12px 0 0; font-weight: 700; }
+.feedback.is-success { color: var(--success); }
+.feedback.is-error { color: var(--error); }
+
+@keyframes shake { 25% { transform: translateX(-4px); } 50% { transform: translateX(4px); } 100% { transform: translateX(0); } }
+@keyframes pulse { 50% { transform: scale(1.04); } }
+
 @media (max-width: 640px) {
-  .syllable-piece { min-width:72px; font-size:1.05rem; }
   .panel { padding: 16px; }
+  .syllable-piece { min-width: 72px; font-size: 1.05rem; }
 }


### PR DESCRIPTION
### Motivation
- Separar claramente la pantalla de entrada (home) de la zona de ejercicios para que la app se sienta como una plataforma real y no una demo con todo en la misma pantalla.
- Introducir una navegación simple y escalable entre vistas sin mezclar lógica de presentación y ejercicio, manteniendo la arquitectura modular existente.
- Mantener intacto el ejercicio actual, el sistema de dataset/filtros y la experiencia responsive, y asegurar que las sílabas se muestren siempre en mayúsculas solo a nivel visual.

### Description
- Reorganicé el HTML creando dos vistas independientes en `index.html`: la `home` con título, explicación y un menú de ejercicios, y la `exercise` con la UI del ejercicio; añadí tarjetas deshabilitadas de ejemplo para futuros ejercicios (`Intruso silábico`, `Memoria`).
- Reemplacé el enrutamiento por un `createRouter` en `src/navigation/router.js` que usa un mapa de `views` y controla visibilidad con la propiedad `hidden` para mantener separación limpia entre vistas.
- Actualicé `main.js` para usar el nuevo router, inicializar la vista Home y abrir el ejercicio activo (`order-syllables`) sin tocar la lógica de selección/validación de palabras; la renderización de sílabas ya convierte visualmente a mayúsculas en `renderRound` y `updateAnswerSlots`.
- Ajusté `src/ui/home.js` para marcar tarjetas no disponibles con `aria-disabled` y evitar enlazarlas, y renové `style.css` para una estética más limpia/minimalista, responsive y con `text-transform: uppercase` en piezas y slots para garantizar el display en mayúsculas.

### Testing
- Ejecuté comprobaciones de sintaxis con `node --check main.js` y `node --check src/navigation/router.js` y `node --check src/ui/home.js` y `node --check src/exercises/orderSyllables.js`, las cuales completaron sin errores.
- Verifiqué manualmente que la navegación muestra/oculta completamente las vistas `home` y `exercise` y que el ejercicio `Ordenar sílabas` funciona con las sílabas mostradas en mayúsculas sin cambiar el dataset ni la lógica de validación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdbed7733c832d9845545a830a8c5b)