### PR TITLE
Implementar navegación real entre Home y Ejercicio

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="app">
-    <section id="home-screen" class="panel home-screen">
+  <div id="app-root" class="app">
+    <section id="home-screen" class="view panel home-screen">
       <p class="eyebrow">Plataforma educativa</p>
       <h1>TITULO</h1>
       <p class="subtitle">Una experiencia interactiva para practicar habilidades lingüísticas con ejercicios breves, claros y progresivos.</p>
@@ -18,13 +18,21 @@
           <strong>Ordenar sílabas</strong>
           <span>Organiza sílabas para formar palabras correctamente.</span>
         </button>
+        <button type="button" class="exercise-card is-disabled" data-status="coming-soon" disabled>
+          <strong>Intruso silábico</strong>
+          <span>Próximamente.</span>
+        </button>
+        <button type="button" class="exercise-card is-disabled" data-status="coming-soon" disabled>
+          <strong>Memoria</strong>
+          <span>Próximamente.</span>
+        </button>
       </nav>
     </section>
 
-    <section id="exercise-screen" class="exercise-screen is-hidden">
+    <section id="exercise-screen" class="view exercise-screen">
       <header class="app-header panel">
         <div class="header-top-row">
-          <button id="home-btn" class="back-btn" type="button" aria-label="Volver a la portada">Inicio</button>
+          <button id="home-btn" class="back-btn" type="button" aria-label="Volver a la portada">Volver</button>
           <p class="eyebrow">Ejercicio base de plataforma</p>
         </div>
         <h1>Ordenar sílabas</h1>

--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ import { createHomeController } from './src/ui/home.js';
 import { createRouter } from './src/navigation/router.js';
 
 const refs = {
+  appRoot: document.querySelector('#app-root'),
   homeScreen: document.querySelector('#home-screen'),
   exerciseScreen: document.querySelector('#exercise-screen'),
   homeBtn: document.querySelector('#home-btn'),
@@ -31,8 +32,11 @@ const POSITION_PATTERNS = {
 };
 
 const router = createRouter({
-  homeScreen: refs.homeScreen,
-  exerciseScreen: refs.exerciseScreen
+  root: refs.appRoot,
+  views: {
+    home: refs.homeScreen,
+    exercise: refs.exerciseScreen
+  }
 });
 
 function setFeedback(message, type = '') {
@@ -162,7 +166,7 @@ function openExercise(exerciseId) {
     return;
   }
 
-  router.showExercise();
+  router.navigateExercise();
   state.score = 0;
   refs.score.textContent = '0';
   setLevel(1);
@@ -183,9 +187,9 @@ function init() {
   });
 
   refs.nextBtn.addEventListener('click', startRound);
-  refs.homeBtn.addEventListener('click', () => router.showHome());
+  refs.homeBtn.addEventListener('click', () => router.navigateHome());
 
-  router.showHome();
+  router.init('home');
 }
 
 init();

--- a/src/navigation/router.js
+++ b/src/navigation/router.js
@@ -1,17 +1,52 @@
-const SCREENS = {
+const VIEWS = {
   home: 'home',
   exercise: 'exercise'
 };
 
-export function createRouter({ homeScreen, exerciseScreen }) {
-  function show(screen) {
-    const showHome = screen === SCREENS.home;
-    homeScreen.classList.toggle('is-hidden', !showHome);
-    exerciseScreen.classList.toggle('is-hidden', showHome);
+export function createRouter({ views, root }) {
+  const state = {
+    activeView: VIEWS.home,
+    isAnimating: false
+  };
+
+  const TRANSITION_MS = 220;
+
+  function render() {
+    Object.entries(views).forEach(([viewName, element]) => {
+      const isActive = state.activeView === viewName;
+      element.classList.toggle('is-active-view', isActive);
+      element.classList.toggle('is-inactive-view', !isActive);
+      element.setAttribute('aria-hidden', String(!isActive));
+    });
+  }
+
+  function navigate(nextView) {
+    if (!views[nextView] || state.activeView === nextView || state.isAnimating) {
+      return;
+    }
+
+    state.isAnimating = true;
+    root.classList.add('is-transitioning');
+    state.activeView = nextView;
+    render();
+
+    window.setTimeout(() => {
+      root.classList.remove('is-transitioning');
+      state.isAnimating = false;
+    }, TRANSITION_MS);
+  }
+
+  function init(initialView = VIEWS.home) {
+    if (views[initialView]) {
+      state.activeView = initialView;
+    }
+    render();
   }
 
   return {
-    showHome: () => show(SCREENS.home),
-    showExercise: () => show(SCREENS.exercise)
+    init,
+    navigateHome: () => navigate(VIEWS.home),
+    navigateExercise: () => navigate(VIEWS.exercise),
+    getActiveView: () => state.activeView
   };
 }

--- a/src/ui/home.js
+++ b/src/ui/home.js
@@ -4,8 +4,11 @@ export function createHomeController({ homeScreen, onSelectExercise }) {
   function bindEvents() {
     cards.forEach((card) => {
       card.addEventListener('click', () => {
-        const exerciseId = card.dataset.exercise;
-        onSelectExercise(exerciseId);
+        if (card.disabled || card.dataset.status === 'coming-soon') {
+          return;
+        }
+
+        onSelectExercise(card.dataset.exercise);
       });
     });
   }

--- a/style.css
+++ b/style.css
@@ -12,14 +12,41 @@
 }
 * { box-sizing: border-box; }
 body { margin:0; font-family: system-ui,sans-serif; background: linear-gradient(180deg,#f8f5f0,#eee6dc); color:var(--text); }
-.app { width:min(100% - 24px,860px); margin:24px auto; display:grid; gap:16px; }
+
+.app {
+  width:min(100% - 24px,860px);
+  margin:24px auto;
+  position: relative;
+  min-height: calc(100dvh - 48px);
+}
+
+.view {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  gap: 16px;
+  align-content: start;
+  opacity: 0;
+  transform: translateY(8px);
+  pointer-events: none;
+  visibility: hidden;
+  transition: opacity 220ms ease, transform 220ms ease, visibility 0s linear 220ms;
+}
+
+.view.is-active-view {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  visibility: visible;
+  transition: opacity 220ms ease, transform 220ms ease;
+}
+
 .panel { background:rgba(255,255,255,.86); border:1px solid var(--line); border-radius:24px; padding:20px; }
 .eyebrow { margin:0 0 6px; font-size:.8rem; text-transform:uppercase; letter-spacing:.1em; color:var(--muted); font-weight:800; }
 h1,h2 { margin:0; }
 .subtitle { margin:8px 0 0; color:var(--muted); }
-.is-hidden { display: none; }
 
-.home-screen { display: grid; gap: 18px; }
+.home-screen { gap: 18px; }
 .exercise-menu { display: grid; gap: 10px; }
 .exercise-card {
   width: 100%;
@@ -33,8 +60,9 @@ h1,h2 { margin:0; }
 }
 .exercise-card strong { font-size: 1rem; }
 .exercise-card span { color: var(--muted); font-size: .92rem; }
+.exercise-card.is-disabled { opacity: 0.55; cursor: not-allowed; }
 
-.exercise-screen { display: grid; gap: 16px; }
+.exercise-screen { gap: 16px; }
 .header-top-row { display: flex; align-items: center; gap: 10px; margin-bottom: 4px; }
 .back-btn { border:1px solid var(--line); background:#fff; border-radius:999px; min-height:38px; padding:0 14px; font-weight:700; }
 


### PR DESCRIPTION
### Motivation
- Convertir la UI que apilaba secciones en scroll a un sistema de vistas donde solo una vista está visible a la vez (`home` / `exercise`).
- Proveer una navegación clara y reversible (botón `Volver`) que deje intacta la lógica del ejercicio (dataset, niveles, validación).

### Description
- Añadido un `createRouter` en `src/navigation/router.js` que mantiene `activeView`, gestiona transiciones y expone `init`, `navigateHome` y `navigateExercise`.
- Reconectado `main.js` para usar `#app-root` y el nuevo router (`router.init`, `router.navigateExercise`, `router.navigateHome`) sin tocar la lógica del ejercicio existente.
- Reestructurada `index.html` para dejar Home y Exercise como vistas separadas dentro de `#app-root`, añadido entradas de menú marcadas como `coming-soon` y botón `Volver` dentro del ejercicio.
- Estilos actualizados en `style.css` para superponer vistas y aplicar una transición suave (fade/slide ligera) mediante las clases `view` y `is-active-view`.
- Mejorado el controlador de Home en `src/ui/home.js` para ignorar cartas deshabilitadas (`disabled` / `data-status="coming-soon"`) y evitar navegación no intencionada.

### Testing
- Ejecutado `node --check main.js` y la verificación ha sido satisfactoria.
- Ejecutado `node --check src/navigation/router.js` y la verificación ha sido satisfactoria.
- Ejecutado `node --check src/ui/home.js` y la verificación ha sido satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd70c3224832d8bbeb4854a7b91ce)