### PR TITLE
Arquitectura de ejercicios: sistema de plugins, validación de corpus y mejoras de accesibilidad

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,8 +1,9 @@
 import { validateWords } from './src/core/validateWords.js';
 import { WORDS } from './src/data/words/index.js';
-import { createOrderSyllablesRound } from './src/exercises/orderSyllables.js';
 import { createHomeController } from './src/ui/home.js';
 import { createRouter } from './src/navigation/router.js';
+import { createExerciseRegistry } from './src/core/exerciseRegistry.js';
+import { createOrderSyllablesPlugin } from './src/exercises/orderSyllablesPlugin.js';
 
 const refs = {
   appRoot: document.querySelector('#app-root'),
@@ -18,26 +19,17 @@ const refs = {
   nextBtn: document.querySelector('#next-btn')
 };
 
-const state = {
-  level: 1,
-  score: 0,
-  round: null,
-  answer: []
-};
-
 const POSITION_PATTERNS = {
   2: ['slot-a', 'slot-d'],
   3: ['slot-a', 'slot-c', 'slot-e'],
   4: ['slot-a', 'slot-b', 'slot-d', 'slot-f']
 };
 
-const router = createRouter({
-  root: refs.appRoot,
-  views: {
-    home: refs.homeScreen,
-    exercise: refs.exerciseScreen
-  }
-});
+const state = { activeExerciseId: null, currentLevel: 1 };
+const registry = createExerciseRegistry();
+registry.register(createOrderSyllablesPlugin());
+
+const router = createRouter({ root: refs.appRoot, views: { home: refs.homeScreen, exercise: refs.exerciseScreen } });
 
 function setFeedback(message, type = '') {
   refs.feedback.textContent = message;
@@ -48,30 +40,41 @@ function getLayoutClass(pieceCount) {
   return POSITION_PATTERNS[pieceCount] ?? POSITION_PATTERNS[3];
 }
 
-function renderRound() {
-  const round = state.round;
+function updateAnswerSlots(answer = []) {
+  const slots = refs.exerciseContainer.querySelectorAll('.answer-slot');
+  slots.forEach((slot, index) => {
+    slot.textContent = answer[index]?.toUpperCase() ?? '';
+  });
+}
 
-  if (!round) {
+function renderRound(viewModel) {
+  if (!viewModel || viewModel.status !== 'ready') {
     refs.exerciseContainer.innerHTML = '';
     setFeedback('No hay palabras disponibles con esos filtros.', 'error');
     return;
   }
 
-  refs.levelLabel.textContent = round.levelLabel;
-  refs.roundWord.textContent = `${round.word.syllables.length} sílabas`;
+  refs.levelLabel.textContent = viewModel.levelLabel;
+  refs.roundWord.textContent = `${viewModel.expectedLength} sílabas`;
 
   const piecesWrap = document.createElement('div');
   piecesWrap.className = 'pieces-cloud';
+  const slots = getLayoutClass(viewModel.pieces.length);
 
-  const slots = getLayoutClass(round.pieces.length);
-
-  round.pieces.forEach((piece, index) => {
+  viewModel.pieces.forEach((piece, index) => {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = `syllable-piece ${slots[index] ?? 'slot-c'}`;
     button.textContent = piece.text.toUpperCase();
     button.dataset.syllable = piece.text;
+    button.setAttribute('aria-label', `Sílaba ${piece.text.toUpperCase()}`);
     button.addEventListener('click', () => handleSyllableTap(button));
+    button.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        handleSyllableTap(button);
+      }
+    });
     piecesWrap.appendChild(button);
   });
 
@@ -81,37 +84,32 @@ function renderRound() {
 
   const slotsWrap = document.createElement('div');
   slotsWrap.className = 'answer-slots';
-
-  for (let index = 0; index < round.expectedLength; index += 1) {
+  for (let index = 0; index < viewModel.expectedLength; index += 1) {
     const slot = document.createElement('div');
     slot.className = 'answer-slot';
     slot.dataset.index = String(index);
+    slot.setAttribute('aria-hidden', 'true');
     slotsWrap.appendChild(slot);
   }
 
   answerWrap.appendChild(slotsWrap);
-
   refs.exerciseContainer.innerHTML = '';
   refs.exerciseContainer.append(piecesWrap, answerWrap);
+  updateAnswerSlots(viewModel.answer);
+  piecesWrap.querySelector('.syllable-piece')?.focus();
 }
 
-function updateAnswerSlots() {
-  const slots = refs.exerciseContainer.querySelectorAll('.answer-slot');
-
-  slots.forEach((slot, index) => {
-    slot.textContent = state.answer[index]?.toUpperCase() ?? '';
-  });
+function getActivePlugin() {
+  return registry.get(state.activeExerciseId);
 }
 
 function handleSyllableTap(button) {
-  if (!state.round || state.answer.length >= state.round.expectedLength) {
-    return;
-  }
+  const plugin = getActivePlugin();
+  if (!plugin) return;
 
-  const expected = state.round.word.syllables[state.answer.length];
-  const tapped = button.dataset.syllable;
+  const result = plugin.submit({ type: 'tap', syllable: button.dataset.syllable });
 
-  if (tapped !== expected) {
+  if (result.status === 'error') {
     button.classList.remove('is-wrong');
     void button.offsetWidth;
     button.classList.add('is-wrong');
@@ -119,67 +117,57 @@ function handleSyllableTap(button) {
     return;
   }
 
-  state.answer.push(tapped);
-  updateAnswerSlots();
-  button.classList.remove('is-correct');
-  void button.offsetWidth;
-  button.classList.add('is-correct');
-  setFeedback('¡Bien! Sigue.', 'success');
-
-  if (state.answer.length === state.round.expectedLength) {
-    validateRound();
+  if (result.answer) {
+    updateAnswerSlots(result.answer);
   }
-}
 
-function validateRound() {
-  const answer = state.answer.join('-');
-
-  if (answer === state.round.correctAnswer) {
-    state.score += 1;
-    refs.score.textContent = String(state.score);
-    setFeedback('Excelente. Nueva palabra…', 'success');
-    window.setTimeout(startRound, 900);
+  if (result.status === 'progress') {
+    button.classList.remove('is-correct');
+    void button.offsetWidth;
+    button.classList.add('is-correct');
+    setFeedback('¡Bien! Sigue.', 'success');
     return;
   }
 
-  refs.exerciseContainer.querySelector('.answer-zone')?.classList.add('is-wrong');
-  setFeedback('Orden incorrecto. Probemos otra vez.', 'error');
-  state.answer = [];
-  window.setTimeout(updateAnswerSlots, 250);
+  if (result.status === 'correct') {
+    refs.score.textContent = String(result.score);
+    setFeedback('Excelente. Nueva palabra…', 'success');
+    window.setTimeout(startRound, 900);
+  }
 }
 
 function startRound() {
-  state.answer = [];
-  state.round = createOrderSyllablesRound(state.level);
-  renderRound();
+  const plugin = getActivePlugin();
+  if (!plugin) return;
+  renderRound(plugin.start({ level: state.currentLevel }));
   setFeedback('Toca las sílabas en orden para formar una palabra.', '');
 }
 
 function setLevel(level) {
-  state.level = level;
+  state.currentLevel = level;
   refs.levelButtons.forEach((btn) => btn.classList.toggle('is-active', Number(btn.dataset.level) === level));
-  startRound();
+  const plugin = getActivePlugin();
+  renderRound(plugin.start({ level }));
+  setFeedback('Toca las sílabas en orden para formar una palabra.', '');
 }
 
 function openExercise(exerciseId) {
-  if (exerciseId !== 'order-syllables') {
+  const plugin = registry.get(exerciseId);
+  if (!plugin) {
     return;
   }
 
+  state.activeExerciseId = exerciseId;
   router.navigateExercise();
-  state.score = 0;
   refs.score.textContent = '0';
+  plugin.start({ level: 1, resetScore: true });
   setLevel(1);
 }
 
 function init() {
   validateWords(WORDS);
 
-  const homeController = createHomeController({
-    homeScreen: refs.homeScreen,
-    onSelectExercise: openExercise
-  });
-
+  const homeController = createHomeController({ homeScreen: refs.homeScreen, onSelectExercise: openExercise });
   homeController.bindEvents();
 
   refs.levelButtons.forEach((button) => {
@@ -187,7 +175,17 @@ function init() {
   });
 
   refs.nextBtn.addEventListener('click', startRound);
-  refs.homeBtn.addEventListener('click', () => router.navigateHome());
+  refs.nextBtn.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      startRound();
+    }
+  });
+
+  refs.homeBtn.addEventListener('click', () => {
+    router.navigateHome();
+    setFeedback('');
+  });
 
   router.init('home');
 }

--- a/src/core/exerciseRegistry.js
+++ b/src/core/exerciseRegistry.js
@@ -1,0 +1,28 @@
+export function createExerciseRegistry() {
+  const plugins = new Map();
+
+  return {
+    register(plugin) {
+      if (!plugin || typeof plugin !== 'object') {
+        throw new Error('Invalid plugin definition.');
+      }
+
+      if (!plugin.id || typeof plugin.id !== 'string') {
+        throw new Error('Plugin requires a string id.');
+      }
+
+      const requiredMethods = ['start', 'submit', 'next', 'getMetrics'];
+      requiredMethods.forEach((methodName) => {
+        if (typeof plugin[methodName] !== 'function') {
+          throw new Error(`Plugin "${plugin.id}" is missing method: ${methodName}`);
+        }
+      });
+
+      plugins.set(plugin.id, plugin);
+      return plugin;
+    },
+    get(id) {
+      return plugins.get(id) ?? null;
+    }
+  };
+}

--- a/src/core/recentHistory.js
+++ b/src/core/recentHistory.js
@@ -1,0 +1,35 @@
+export function createRecentHistory(limit = 8) {
+  const queue = [];
+  const lookup = new Set();
+
+  function add(id) {
+    if (!id) {
+      return;
+    }
+
+    if (lookup.has(id)) {
+      const index = queue.indexOf(id);
+      if (index >= 0) {
+        queue.splice(index, 1);
+      }
+    }
+
+    queue.push(id);
+    lookup.add(id);
+
+    if (queue.length > limit) {
+      const removed = queue.shift();
+      lookup.delete(removed);
+    }
+  }
+
+  return {
+    add,
+    has: (id) => lookup.has(id),
+    clear: () => {
+      queue.length = 0;
+      lookup.clear();
+    },
+    snapshot: () => [...queue]
+  };
+}

--- a/src/core/validateWords.js
+++ b/src/core/validateWords.js
@@ -1,16 +1,8 @@
-const ALLOWED_CATEGORIES = new Set([
-  'animales',
-  'hogar',
-  'comida',
-  'escuela',
-  'cuerpo',
-  'juguetes',
-  'ropa',
-  'naturaleza'
-]);
-
+const ALLOWED_CATEGORIES = new Set(['animales', 'hogar', 'comida', 'escuela', 'cuerpo', 'juguetes', 'ropa', 'naturaleza']);
 const ALLOWED_DIFFICULTIES = new Set([1, 2, 3, 4]);
-const ID_PATTERN = /^lvl\d+_[a-z]+_[a-z0-9áéíóúüñ]+$/i;
+const ALLOWED_FREQUENCIES = new Set([1, 2, 3]);
+const ID_PATTERN = /^lvl(\d+)_([a-z]+)_([a-z0-9áéíóúüñ]+)$/i;
+const STRUCTURE_PATTERN = /^(CV|CVC|VC)(-(CV|CVC|VC))*$/;
 
 function logWordsError(message) {
   console.error('[WORDS ERROR]');
@@ -30,7 +22,6 @@ export function validateWords(words) {
 
   let errors = 0;
   let warnings = 0;
-
   const ids = new Map();
   const wordsByValue = new Map();
 
@@ -43,13 +34,15 @@ export function validateWords(words) {
       return;
     }
 
+    let parsedId = null;
     if (!entry.id || typeof entry.id !== 'string' || entry.id.trim() === '') {
       errors += 1;
       logWordsError(`Empty id in word: ${ref}`);
     } else {
       const normalizedId = entry.id.trim();
+      parsedId = normalizedId.match(ID_PATTERN);
 
-      if (!ID_PATTERN.test(normalizedId)) {
+      if (!parsedId) {
         errors += 1;
         logWordsError(`Malformed id: ${entry.id}`);
       }
@@ -73,22 +66,31 @@ export function validateWords(words) {
       wordsByValue.get(normalizedWord).push(entry);
     }
 
-    if (!entry.category || typeof entry.category !== 'string' || entry.category.trim() === '') {
+    const normalizedCategory = entry.category?.trim().toLowerCase();
+    if (!normalizedCategory) {
       errors += 1;
       logWordsError(`Empty category in word: ${ref}`);
-    } else if (!ALLOWED_CATEGORIES.has(entry.category.trim().toLowerCase())) {
-      warnings += 1;
-      logWordsWarning(`Category not allowed in word ${ref}: ${entry.category}`);
+    } else if (!ALLOWED_CATEGORIES.has(normalizedCategory)) {
+      errors += 1;
+      logWordsError(`Category not allowed in word ${ref}: ${entry.category}`);
     }
 
     if (!entry.structure || typeof entry.structure !== 'string' || entry.structure.trim() === '') {
       errors += 1;
       logWordsError(`Empty structure in word: ${ref}`);
+    } else if (!STRUCTURE_PATTERN.test(entry.structure.trim())) {
+      errors += 1;
+      logWordsError(`Invalid structure format in word ${ref}: ${entry.structure}`);
     }
 
     if (!ALLOWED_DIFFICULTIES.has(entry.difficulty)) {
       errors += 1;
       logWordsError(`Invalid difficulty in word ${ref}: ${entry.difficulty}`);
+    }
+
+    if (!ALLOWED_FREQUENCIES.has(entry.frequency)) {
+      errors += 1;
+      logWordsError(`Invalid frequency in word ${ref}: ${entry.frequency}`);
     }
 
     if (!Array.isArray(entry.syllables) || entry.syllables.length === 0) {
@@ -102,6 +104,11 @@ export function validateWords(words) {
       logWordsError(`Incorrect syllableCount in word: ${ref}`);
     }
 
+    if (entry.structure && entry.syllableCount && entry.structure.split('-').length !== entry.syllableCount) {
+      errors += 1;
+      logWordsError(`Structure and syllableCount mismatch in word: ${ref}`);
+    }
+
     if (entry.initialSyllable !== entry.syllables[0]) {
       errors += 1;
       logWordsError(`Incorrect initialSyllable in word: ${ref}`);
@@ -111,17 +118,29 @@ export function validateWords(words) {
       errors += 1;
       logWordsError(`Incorrect finalSyllable in word: ${ref}`);
     }
+
+    if (parsedId) {
+      const [, levelId, categoryId, wordId] = parsedId;
+      if (Number(levelId) !== entry.difficulty) {
+        errors += 1;
+        logWordsError(`ID level and difficulty mismatch in ${entry.id}`);
+      }
+      if (normalizedCategory && categoryId !== normalizedCategory) {
+        warnings += 1;
+        logWordsWarning(`ID category and category mismatch in ${entry.id}`);
+      }
+      if (entry.word && wordId !== entry.word.toLowerCase()) {
+        warnings += 1;
+        logWordsWarning(`ID word segment and word mismatch in ${entry.id}`);
+      }
+    }
   });
 
   wordsByValue.forEach((entries, normalizedWord) => {
     if (entries.length > 1) {
       const categories = [...new Set(entries.map((item) => item.category || 'sin-categoría'))].join(', ');
       warnings += 1;
-      logWordsWarning(
-        `Duplicate word detected: ${normalizedWord}. Categories: ${categories}. IDs: ${entries
-          .map((item) => item.id)
-          .join(', ')}`
-      );
+      logWordsWarning(`Duplicate word detected: ${normalizedWord}. Categories: ${categories}. IDs: ${entries.map((item) => item.id).join(', ')}`);
     }
   });
 

--- a/src/exercises/orderSyllablesPlugin.js
+++ b/src/exercises/orderSyllablesPlugin.js
@@ -1,0 +1,228 @@
+import { getFilteredWords, getRandomWord, shuffleArray } from '../core/wordUtils.js';
+import { createRecentHistory } from '../core/recentHistory.js';
+
+export const ORDER_LEVELS = {
+  1: {
+    id: 1,
+    label: 'Nivel 1',
+    filters: {
+      syllableCount: 2,
+      frequency: [1, 2],
+      structure: ['CV-CV']
+    }
+  },
+  2: {
+    id: 2,
+    label: 'Nivel 2',
+    filters: {
+      syllableCount: 3,
+      frequency: [1, 2],
+      structure: ['CV-CV-CV']
+    }
+  },
+  3: {
+    id: 3,
+    label: 'Nivel 3',
+    filters: {
+      syllableCount: 3,
+      frequency: 3
+    }
+  }
+};
+
+function createSyllablePieces(syllables) {
+  return shuffleArray(syllables).map((text, index) => ({ id: `${text}-${index}`, text }));
+}
+
+function classifyError({ expected, tapped, submitted, target }) {
+  if (tapped && expected && tapped !== expected) {
+    return 'orden_incorrecto';
+  }
+
+  if (!submitted || !target) {
+    return 'orden_incorrecto';
+  }
+
+  if (submitted.length < target.length) {
+    return 'omision';
+  }
+
+  const sameItems = [...submitted].sort().join('|') === [...target].sort().join('|');
+  if (submitted.length === target.length && sameItems && submitted.join('-') !== target.join('-')) {
+    return 'inversion';
+  }
+
+  return 'orden_incorrecto';
+}
+
+export function createOrderSyllablesPlugin() {
+  const state = {
+    level: 1,
+    round: null,
+    answer: [],
+    score: 0,
+    metrics: {
+      roundsPlayed: 0,
+      roundsCorrect: 0,
+      errorsByType: {
+        inversion: 0,
+        omision: 0,
+        orden_incorrecto: 0
+      }
+    }
+  };
+
+  const recentHistory = createRecentHistory(10);
+
+  function getCandidates(level) {
+    const config = ORDER_LEVELS[level] ?? ORDER_LEVELS[1];
+    const all = getFilteredWords(config.filters);
+    const fresh = all.filter((word) => !recentHistory.has(word.id));
+
+    return {
+      config,
+      pool: fresh.length > 0 ? fresh : all
+    };
+  }
+
+  function makeRound(level = state.level) {
+    const { config, pool } = getCandidates(level);
+    const word = getRandomWord(pool);
+
+    if (!word) {
+      return null;
+    }
+
+    return {
+      level: config.id,
+      levelLabel: config.label,
+      word: {
+        id: word.id,
+        text: word.word,
+        syllables: [...word.syllables]
+      },
+      pieces: createSyllablePieces(word.syllables),
+      expectedLength: word.syllables.length,
+      correctAnswer: word.syllables.join('-')
+    };
+  }
+
+  function start(payload = {}) {
+    if (Number.isInteger(payload.level)) {
+      state.level = payload.level;
+    }
+
+    if (payload.resetScore) {
+      state.score = 0;
+      state.metrics.roundsPlayed = 0;
+      state.metrics.roundsCorrect = 0;
+      state.metrics.errorsByType = { inversion: 0, omision: 0, orden_incorrecto: 0 };
+      recentHistory.clear();
+    }
+
+    state.answer = [];
+    state.round = makeRound(state.level);
+
+    if (!state.round) {
+      return { status: 'empty' };
+    }
+
+    state.metrics.roundsPlayed += 1;
+
+    return {
+      status: 'ready',
+      level: state.round.level,
+      levelLabel: state.round.levelLabel,
+      expectedLength: state.round.expectedLength,
+      pieces: state.round.pieces,
+      wordId: state.round.word.id,
+      answer: []
+    };
+  }
+
+  function submit(payload = {}) {
+    if (!state.round) {
+      return { status: 'empty' };
+    }
+
+    if (payload.type === 'tap') {
+      const tapped = payload.syllable;
+      if (state.answer.length >= state.round.expectedLength) {
+        return { status: 'locked', answer: [...state.answer] };
+      }
+
+      const expected = state.round.word.syllables[state.answer.length];
+
+      if (tapped !== expected) {
+        const errorType = classifyError({ tapped, expected });
+        state.metrics.errorsByType[errorType] += 1;
+        return {
+          status: 'error',
+          errorType,
+          expected,
+          answer: [...state.answer]
+        };
+      }
+
+      state.answer.push(tapped);
+      if (state.answer.length === state.round.expectedLength) {
+        return submit({ type: 'validate' });
+      }
+
+      return {
+        status: 'progress',
+        answer: [...state.answer],
+        completed: false
+      };
+    }
+
+    if (payload.type === 'validate') {
+      const success = state.answer.join('-') === state.round.correctAnswer;
+
+      if (!success) {
+        const errorType = classifyError({ submitted: state.answer, target: state.round.word.syllables });
+        state.metrics.errorsByType[errorType] += 1;
+        return {
+          status: 'incorrect',
+          errorType,
+          answer: [...state.answer],
+          targetLength: state.round.expectedLength
+        };
+      }
+
+      state.score += 1;
+      state.metrics.roundsCorrect += 1;
+      recentHistory.add(state.round.word.id);
+
+      return {
+        status: 'correct',
+        score: state.score,
+        answer: [...state.answer],
+        wordId: state.round.word.id
+      };
+    }
+
+    return { status: 'idle' };
+  }
+
+  function next(payload = {}) {
+    if (payload.level !== undefined) {
+      state.level = payload.level;
+    }
+    return start({ level: state.level });
+  }
+
+  return {
+    id: 'order-syllables',
+    start,
+    submit,
+    next,
+    getMetrics: () => ({
+      score: state.score,
+      roundsPlayed: state.metrics.roundsPlayed,
+      roundsCorrect: state.metrics.roundsCorrect,
+      errorsByType: { ...state.metrics.errorsByType },
+      recentWordIds: recentHistory.snapshot()
+    })
+  };
+}

--- a/style.css
+++ b/style.css
@@ -104,3 +104,8 @@ h1,h2 { margin:0; }
   .syllable-piece { min-width:72px; font-size:1.05rem; }
   .panel { padding: 16px; }
 }
+
+button:focus-visible { outline: 3px solid #1d6ef2; outline-offset: 2px; }
+.exercise-card,.level-btn,.secondary-btn,.back-btn,.syllable-piece { cursor: pointer; }
+.syllable-piece { font-size: clamp(1rem, 2.6vw, 1.25rem); }
+.answer-slot { min-width: clamp(64px, 18vw, 74px); }


### PR DESCRIPTION
### Motivation
- Separar la lógica de ejercicios de la orquestación para permitir añadir nuevos ejercicios modulares sin `main.js` hardcodeado. 
- Robustecer la calidad del corpus para detectar duplicados, ids inválidos y inconsistencias antes de ejecutar la app. 
- Reducir repetición temprana de palabras y empezar a capturar tipos de error básicos para futuras adaptaciones sin backend ni persistencia compleja. 

### Description
- Se añadió un registro liviano de plugins `createExerciseRegistry()` que exige la interfaz común `start()`, `submit()`, `next()` y `getMetrics()` y permite registrar nuevos ejercicios. 
- Se migró la lógica de “Ordenar sílabas” a `src/exercises/orderSyllablesPlugin.js` como plugin que implementa selección por nivel, flujo de ronda, historial reciente en sesión y métricas básicas (incluyendo `inversion`, `omision`, `orden_incorrecto`). 
- Se introdujo la memoria reciente en `src/core/recentHistory.js` para evitar reutilizar palabras vistas recientemente y se añadió `src/core/exerciseRegistry.js` para gestión de plugins. 
- Se reforzó `src/core/validateWords.js` con comprobaciones adicionales (frecuencia permitida, formato de `structure`, consistencia `structure`/`syllableCount`, coincidencia `id`↔`difficulty`, detección de duplicados y avisos de inconsistencia) y se actualizaron `main.js` y `style.css` para orquestar plugins y mejorar accesibilidad (soporte `Enter`/`Space`, `focus-visible`, tamaños adaptables). 

### Testing
- Se ejecutó la verificación de sintaxis con `node --check main.js` y la comprobación finalizó correctamente. 
- Se ejecutó la verificación de sintaxis con `node --check src/exercises/orderSyllablesPlugin.js` y la comprobación finalizó correctamente. 
- Se ejecutó la verificación de sintaxis con `node --check src/core/validateWords.js` y la comprobación finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae67492b8832d9cf59bbe05bd89f1)