### PR TITLE
Separar niveles lingüísticos y preparar arquitectura de modos cognitivos

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,11 @@
           <button class="level-btn" data-level="3">Nivel 3</button>
         </div>
 
+        <div class="mode-tabs" aria-label="Selector de modo">
+          <button class="mode-btn is-active" data-mode="normal">Normal</button>
+          <button class="mode-btn" data-mode="intruders" disabled title="Próximamente">Intrusos</button>
+        </div>
+
         <div id="exercise-container" class="exercise-container"></div>
 
         <div class="actions">

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ import { createHomeController } from './src/ui/home.js';
 import { createRouter } from './src/navigation/router.js';
 import { createExerciseRegistry } from './src/core/exerciseRegistry.js';
 import { createOrderSyllablesPlugin } from './src/exercises/orderSyllablesPlugin.js';
+import { ORDER_MODES } from './src/exercises/orderSyllablesConfig.js';
 
 const refs = {
   appRoot: document.querySelector('#app-root'),
@@ -11,6 +12,7 @@ const refs = {
   exerciseScreen: document.querySelector('#exercise-screen'),
   homeBtn: document.querySelector('#home-btn'),
   levelButtons: document.querySelectorAll('.level-btn'),
+  modeButtons: document.querySelectorAll('.mode-btn'),
   exerciseContainer: document.querySelector('#exercise-container'),
   feedback: document.querySelector('#feedback'),
   score: document.querySelector('#score'),
@@ -25,7 +27,7 @@ const POSITION_PATTERNS = {
   4: ['slot-a', 'slot-b', 'slot-d', 'slot-f']
 };
 
-const state = { activeExerciseId: null, currentLevel: 1 };
+const state = { activeExerciseId: null, currentLevel: 1, currentMode: 'normal' };
 const registry = createExerciseRegistry();
 registry.register(createOrderSyllablesPlugin());
 
@@ -55,7 +57,7 @@ function renderRound(viewModel) {
   }
 
   refs.levelLabel.textContent = viewModel.levelLabel;
-  refs.roundWord.textContent = `${viewModel.expectedLength} sílabas`;
+  refs.roundWord.textContent = `${viewModel.expectedLength} sílabas · ${viewModel.modeLabel}`;
 
   const piecesWrap = document.createElement('div');
   piecesWrap.className = 'pieces-cloud';
@@ -139,7 +141,7 @@ function handleSyllableTap(button) {
 function startRound() {
   const plugin = getActivePlugin();
   if (!plugin) return;
-  renderRound(plugin.start({ level: state.currentLevel }));
+  renderRound(plugin.start({ level: state.currentLevel, mode: state.currentMode }));
   setFeedback('Toca las sílabas en orden para formar una palabra.', '');
 }
 
@@ -147,7 +149,22 @@ function setLevel(level) {
   state.currentLevel = level;
   refs.levelButtons.forEach((btn) => btn.classList.toggle('is-active', Number(btn.dataset.level) === level));
   const plugin = getActivePlugin();
-  renderRound(plugin.start({ level }));
+  renderRound(plugin.start({ level, mode: state.currentMode }));
+  setFeedback('Toca las sílabas en orden para formar una palabra.', '');
+}
+
+function setMode(mode) {
+  const modeConfig = ORDER_MODES[mode] ?? ORDER_MODES.normal;
+  if (!modeConfig.enabled) {
+    setFeedback('Este modo estará disponible próximamente.', 'error');
+    return;
+  }
+
+  state.currentMode = modeConfig.id;
+  refs.modeButtons.forEach((btn) => btn.classList.toggle('is-active', btn.dataset.mode === modeConfig.id));
+  const plugin = getActivePlugin();
+  if (!plugin) return;
+  renderRound(plugin.start({ level: state.currentLevel, mode: state.currentMode }));
   setFeedback('Toca las sílabas en orden para formar una palabra.', '');
 }
 
@@ -160,7 +177,7 @@ function openExercise(exerciseId) {
   state.activeExerciseId = exerciseId;
   router.navigateExercise();
   refs.score.textContent = '0';
-  plugin.start({ level: 1, resetScore: true });
+  plugin.start({ level: 1, mode: 'normal', resetScore: true });
   setLevel(1);
 }
 
@@ -172,6 +189,10 @@ function init() {
 
   refs.levelButtons.forEach((button) => {
     button.addEventListener('click', () => setLevel(Number(button.dataset.level)));
+  });
+
+  refs.modeButtons.forEach((button) => {
+    button.addEventListener('click', () => setMode(button.dataset.mode));
   });
 
   refs.nextBtn.addEventListener('click', startRound);

--- a/src/exercises/orderSyllables.js
+++ b/src/exercises/orderSyllables.js
@@ -1,33 +1,13 @@
 import { getFilteredWords, getRandomWord, shuffleArray } from '../core/wordUtils.js';
+import { resolveOrderLevel } from './orderSyllablesConfig.js';
 
-export const ORDER_LEVELS = {
-  1: {
-    id: 1,
-    label: 'Nivel 1',
-    filters: {
-      syllableCount: 2,
-      frequency: [1, 2],
-      structure: ['CV-CV']
-    }
-  },
-  2: {
-    id: 2,
-    label: 'Nivel 2',
-    filters: {
-      syllableCount: 3,
-      frequency: [1, 2],
-      structure: ['CV-CV-CV']
-    }
-  },
-  3: {
-    id: 3,
-    label: 'Nivel 3',
-    filters: {
-      syllableCount: 3,
-      frequency: 3
-    }
+function getLinguisticCandidates(levelConfig) {
+  const base = getFilteredWords(levelConfig.linguisticFilters);
+  if (levelConfig.id !== 3) {
+    return base;
   }
-};
+  return base.filter((word) => word.structure !== 'CV-CV-CV');
+}
 
 function createSyllablePieces(syllables) {
   const shuffled = shuffleArray(syllables);
@@ -40,8 +20,8 @@ function createSyllablePieces(syllables) {
 }
 
 export function createOrderSyllablesRound(level = 1) {
-  const config = ORDER_LEVELS[level] ?? ORDER_LEVELS[1];
-  const candidates = getFilteredWords(config.filters);
+  const config = resolveOrderLevel(level);
+  const candidates = getLinguisticCandidates(config);
   const word = getRandomWord(candidates);
 
   if (!word) {
@@ -51,7 +31,7 @@ export function createOrderSyllablesRound(level = 1) {
   return {
     level: config.id,
     levelLabel: config.label,
-    filters: config.filters,
+    filters: config.linguisticFilters,
     word: {
       id: word.id,
       text: word.word,

--- a/src/exercises/orderSyllablesConfig.js
+++ b/src/exercises/orderSyllablesConfig.js
@@ -1,0 +1,55 @@
+export const ORDER_LEVELS = {
+  1: {
+    id: 1,
+    label: 'Nivel 1',
+    description: '2 sílabas, frecuencia 1-2, estructuras simples (CV-CV).',
+    linguisticFilters: {
+      syllableCount: 2,
+      frequency: [1, 2],
+      structure: ['CV-CV']
+    }
+  },
+  2: {
+    id: 2,
+    label: 'Nivel 2',
+    description: '3 sílabas, frecuencia 1-2, estructuras simples (CV-CV-CV).',
+    linguisticFilters: {
+      syllableCount: 3,
+      frequency: [1, 2],
+      structure: ['CV-CV-CV']
+    }
+  },
+  3: {
+    id: 3,
+    label: 'Nivel 3',
+    description: 'Estructuras mixtas/trabadas, frecuencia 3, palabras más complejas.',
+    linguisticFilters: {
+      frequency: 3,
+      complexity: ['mixed', 'trabadas']
+    }
+  }
+};
+
+export const ORDER_MODES = {
+  normal: {
+    id: 'normal',
+    label: 'Normal',
+    description: 'Sin carga cognitiva extra. Solo orden lingüístico.',
+    enabled: true
+  },
+  intruders: {
+    id: 'intruders',
+    label: 'Intrusos',
+    description: 'Variante cognitiva con sílabas distractoras.',
+    enabled: false
+  }
+};
+
+export function resolveOrderLevel(levelId = 1) {
+  return ORDER_LEVELS[levelId] ?? ORDER_LEVELS[1];
+}
+
+export function resolveOrderMode(modeId = 'normal') {
+  const candidate = ORDER_MODES[modeId] ?? ORDER_MODES.normal;
+  return candidate.enabled ? candidate : ORDER_MODES.normal;
+}

--- a/src/exercises/orderSyllablesPlugin.js
+++ b/src/exercises/orderSyllablesPlugin.js
@@ -1,34 +1,16 @@
 import { getFilteredWords, getRandomWord, shuffleArray } from '../core/wordUtils.js';
 import { createRecentHistory } from '../core/recentHistory.js';
+import { resolveOrderLevel, resolveOrderMode } from './orderSyllablesConfig.js';
 
-export const ORDER_LEVELS = {
-  1: {
-    id: 1,
-    label: 'Nivel 1',
-    filters: {
-      syllableCount: 2,
-      frequency: [1, 2],
-      structure: ['CV-CV']
-    }
-  },
-  2: {
-    id: 2,
-    label: 'Nivel 2',
-    filters: {
-      syllableCount: 3,
-      frequency: [1, 2],
-      structure: ['CV-CV-CV']
-    }
-  },
-  3: {
-    id: 3,
-    label: 'Nivel 3',
-    filters: {
-      syllableCount: 3,
-      frequency: 3
-    }
+function getLinguisticCandidates(levelConfig) {
+  const base = getFilteredWords(levelConfig.linguisticFilters);
+
+  if (levelConfig.id !== 3) {
+    return base;
   }
-};
+
+  return base.filter((word) => word.structure !== 'CV-CV-CV');
+}
 
 function createSyllablePieces(syllables) {
   return shuffleArray(syllables).map((text, index) => ({ id: `${text}-${index}`, text }));
@@ -58,6 +40,7 @@ function classifyError({ expected, tapped, submitted, target }) {
 export function createOrderSyllablesPlugin() {
   const state = {
     level: 1,
+    mode: 'normal',
     round: null,
     answer: [],
     score: 0,
@@ -75,8 +58,8 @@ export function createOrderSyllablesPlugin() {
   const recentHistory = createRecentHistory(10);
 
   function getCandidates(level) {
-    const config = ORDER_LEVELS[level] ?? ORDER_LEVELS[1];
-    const all = getFilteredWords(config.filters);
+    const config = resolveOrderLevel(level);
+    const all = getLinguisticCandidates(config);
     const fresh = all.filter((word) => !recentHistory.has(word.id));
 
     return {
@@ -87,6 +70,7 @@ export function createOrderSyllablesPlugin() {
 
   function makeRound(level = state.level) {
     const { config, pool } = getCandidates(level);
+    const mode = resolveOrderMode(state.mode);
     const word = getRandomWord(pool);
 
     if (!word) {
@@ -96,6 +80,8 @@ export function createOrderSyllablesPlugin() {
     return {
       level: config.id,
       levelLabel: config.label,
+      mode: mode.id,
+      modeLabel: mode.label,
       word: {
         id: word.id,
         text: word.word,
@@ -110,6 +96,10 @@ export function createOrderSyllablesPlugin() {
   function start(payload = {}) {
     if (Number.isInteger(payload.level)) {
       state.level = payload.level;
+    }
+
+    if (payload.mode !== undefined) {
+      state.mode = resolveOrderMode(payload.mode).id;
     }
 
     if (payload.resetScore) {
@@ -133,6 +123,8 @@ export function createOrderSyllablesPlugin() {
       status: 'ready',
       level: state.round.level,
       levelLabel: state.round.levelLabel,
+      mode: state.round.mode,
+      modeLabel: state.round.modeLabel,
       expectedLength: state.round.expectedLength,
       pieces: state.round.pieces,
       wordId: state.round.word.id,
@@ -209,7 +201,10 @@ export function createOrderSyllablesPlugin() {
     if (payload.level !== undefined) {
       state.level = payload.level;
     }
-    return start({ level: state.level });
+    if (payload.mode !== undefined) {
+      state.mode = resolveOrderMode(payload.mode).id;
+    }
+    return start({ level: state.level, mode: state.mode });
   }
 
   return {

--- a/style.css
+++ b/style.css
@@ -69,8 +69,10 @@ h1,h2 { margin:0; }
 .exercise-top { display:flex; justify-content:space-between; align-items:center; }
 .score-box { background:var(--surface-soft); border-radius:14px; padding:8px 14px; text-align:center; }
 .level-tabs { display:flex; gap:8px; margin:18px 0; flex-wrap:wrap; }
-.level-btn,.secondary-btn { border:1px solid var(--line); background:#fff; border-radius:999px; min-height:44px; padding:0 16px; font-weight:700; }
-.level-btn.is-active { background:var(--accent); color:#fff; }
+.mode-tabs { display:flex; gap:8px; margin:-8px 0 18px; flex-wrap:wrap; }
+.level-btn,.mode-btn,.secondary-btn { border:1px solid var(--line); background:#fff; border-radius:999px; min-height:44px; padding:0 16px; font-weight:700; }
+.level-btn.is-active,.mode-btn.is-active { background:var(--accent); color:#fff; }
+.mode-btn[disabled] { opacity:.5; cursor:not-allowed; }
 .exercise-container { display:grid; gap:18px; }
 .pieces-cloud {
   position: relative;
@@ -106,6 +108,6 @@ h1,h2 { margin:0; }
 }
 
 button:focus-visible { outline: 3px solid #1d6ef2; outline-offset: 2px; }
-.exercise-card,.level-btn,.secondary-btn,.back-btn,.syllable-piece { cursor: pointer; }
+.exercise-card,.level-btn,.mode-btn,.secondary-btn,.back-btn,.syllable-piece { cursor: pointer; }
 .syllable-piece { font-size: clamp(1rem, 2.6vw, 1.25rem); }
 .answer-slot { min-width: clamp(64px, 18vw, 74px); }


### PR DESCRIPTION
### Motivation
- Aclarar la diferencia pedagógica entre `niveles` (solo dificultad lingüística) y `modos` (variantes cognitivas) para evitar mezclar propiedades lingüísticas con demanda cognitiva. 
- Mantener la arquitectura modular y el sistema de plugins existente sin introducir backend ni dependencias externas, y conservar JavaScript vanilla. 

### Description
- Añadí `src/exercises/orderSyllablesConfig.js` que expone `ORDER_LEVELS`, `ORDER_MODES`, `resolveOrderLevel` y `resolveOrderMode` para centralizar la configuración lingüística y de modos. 
- Refactoricé `src/exercises/orderSyllables.js` para usar `resolveOrderLevel` y una función `getLinguisticCandidates` que aplica únicamente filtros lingüísticos por nivel (con tratamiento especial para `nivel 3`). 
- Actualicé `src/exercises/orderSyllablesPlugin.js` para introducir `state.mode`, propagar el `mode` en `start`/`next`/`makeRound`, y devolver `mode`/`modeLabel` en el view model sin activar todavía las variantes cognitivas (solo `normal` habilitado). 
- Preparé la UI con cambios en `index.html`, `main.js` y `style.css` para añadir un selector visual de modos (botón `Normal` activo y `Intrusos` marcado como "Próximamente") y mostrar `nivel · modo` en la cabecera de ronda. 

### Testing
- Ejecuté `node -e` para inspeccionar estructuras y frecuencias en el dataset y la evaluación devolvió las listas esperadas de `structure` y `frequency`. 
- Ejecuté `node -e` para instanciar el plugin y comprobé que `start({level:1, mode:'normal'})` devuelve `ready` y que `start({level:3, mode:'intruders'})` cae al modo `normal` cuando `intruders` está deshabilitado, ambos con resultado esperado. 
- Todos los comprobadores automáticos realizados en el entorno local (los comandos `node -e` anteriores) terminaron con salida conforme a lo esperado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aeb41732c832d91534f62af67400c)