### PR TITLE
Rediseño UX/UI moderno y separación visual entre Home y Actividad

### DIFF
--- a/src/navigation/router.js
+++ b/src/navigation/router.js
@@ -18,6 +18,9 @@ export function createRouter({ views, root }) {
       element.classList.toggle('is-inactive-view', !isActive);
       element.setAttribute('aria-hidden', String(!isActive));
     });
+
+    root.classList.toggle('is-home-view', state.activeView === VIEWS.home);
+    root.classList.toggle('is-exercise-view', state.activeView === VIEWS.exercise);
   }
 
   function navigate(nextView) {

--- a/style.css
+++ b/style.css
@@ -1,56 +1,50 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap');
+
 :root {
-  --bg: #f4f1eb;
-  --bg-2: #ece5db;
-  --surface: rgba(255, 255, 255, 0.92);
-  --surface-strong: #ffffff;
-  --surface-soft: #f7f3ed;
-  --text: #231d19;
-  --muted: #6f655d;
-  --accent: #6f4f3b;
-  --accent-2: #87624a;
-  --success: #2f7d46;
-  --error: #bf4747;
-  --line: rgba(74, 52, 35, 0.16);
-  --line-soft: rgba(74, 52, 35, 0.1);
-  --shadow-xs: 0 2px 8px rgba(28, 16, 8, 0.05);
-  --shadow-sm: 0 8px 22px rgba(28, 16, 8, 0.08);
-  --shadow-md: 0 16px 38px rgba(28, 16, 8, 0.12);
+  --bg: #f6f7fb;
+  --surface: #ffffff;
+  --surface-soft: #f2f4fd;
+  --text: #1f2544;
+  --muted: #6d7392;
+  --accent: #5b6cff;
+  --accent-strong: #4c5df5;
+  --success: #26a269;
+  --error: #de5a69;
+  --line: #e6eaf7;
+  --shadow-xs: 0 4px 12px rgba(34, 47, 109, 0.08);
+  --shadow-sm: 0 12px 30px rgba(34, 47, 109, 0.12);
+  --shadow-md: 0 24px 48px rgba(27, 41, 101, 0.16);
   --radius-xl: 28px;
   --radius-lg: 20px;
   --radius-md: 16px;
-  --transition: 220ms cubic-bezier(.22, .61, .36, 1);
+  --transition: 240ms cubic-bezier(.22, .61, .36, 1);
 }
 
 * { box-sizing: border-box; }
 
 body {
   margin: 0;
-  font-family: "Nunito", "Avenir Next", "Segoe UI", "Inter", system-ui, -apple-system, sans-serif;
-  background:
-    radial-gradient(1100px 400px at 10% -10%, rgba(255, 255, 255, 0.72), transparent 60%),
-    radial-gradient(900px 340px at 90% -10%, rgba(255, 255, 255, 0.62), transparent 58%),
-    linear-gradient(180deg, var(--bg), var(--bg-2));
+  font-family: 'Poppins', system-ui, -apple-system, sans-serif;
   color: var(--text);
+  background: radial-gradient(900px 500px at 10% 0%, #ffffff 0%, transparent 65%), var(--bg);
 }
 
 .app {
-  width: min(100% - 30px, 940px);
-  margin: 28px auto;
+  width: min(100% - 32px, 1024px);
+  margin: 24px auto;
+  min-height: calc(100dvh - 48px);
   position: relative;
-  min-height: calc(100dvh - 56px);
+  transition: width var(--transition), margin var(--transition);
 }
 
 .view {
   position: absolute;
   inset: 0;
-  display: grid;
-  gap: 20px;
-  align-content: start;
   opacity: 0;
-  transform: translateY(12px) scale(0.996);
+  transform: translateY(16px) scale(0.99);
   pointer-events: none;
   visibility: hidden;
-  transition: opacity var(--transition), transform var(--transition), visibility 0s linear 220ms;
+  transition: opacity var(--transition), transform var(--transition), visibility 0s linear 240ms;
 }
 
 .view.is-active-view {
@@ -63,262 +57,277 @@ body {
 
 .panel {
   background: var(--surface);
-  border: 1px solid var(--line-soft);
+  border: 1px solid var(--line);
   border-radius: var(--radius-xl);
-  padding: clamp(18px, 3vw, 28px);
+  padding: clamp(18px, 2.8vw, 28px);
   box-shadow: var(--shadow-sm);
-  backdrop-filter: blur(6px);
 }
 
 .eyebrow {
   margin: 0 0 8px;
-  font-size: .78rem;
-  text-transform: uppercase;
-  letter-spacing: .11em;
   color: var(--muted);
-  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: .12em;
+  font-size: .75rem;
+  font-weight: 700;
 }
 
-h1, h2 { margin: 0; line-height: 1.14; letter-spacing: -.01em; }
-h1 { font-size: clamp(1.45rem, 2.6vw, 2rem); }
-h2 { font-size: clamp(1.22rem, 2.2vw, 1.65rem); }
+h1, h2 { margin: 0; line-height: 1.16; letter-spacing: -.01em; }
+h1 { font-size: clamp(1.55rem, 2.5vw, 2.1rem); }
+h2 { font-size: clamp(1.2rem, 2vw, 1.65rem); }
 
 .subtitle {
   margin: 10px 0 0;
   color: var(--muted);
-  max-width: 72ch;
-  line-height: 1.5;
+  line-height: 1.55;
+  max-width: 65ch;
 }
 
-.home-screen { gap: 22px; }
-.exercise-menu { display: grid; gap: 12px; }
+.home-screen {
+  gap: 26px;
+  max-width: 760px;
+  margin-inline: auto;
+}
+
+.exercise-menu {
+  display: grid;
+  gap: 14px;
+}
 
 .exercise-card {
   width: 100%;
-  border: 1px solid var(--line-soft);
-  border-radius: 18px;
-  background: linear-gradient(180deg, #fff, #fdfaf7);
-  padding: 16px 18px;
   text-align: left;
-  display: grid;
-  gap: 5px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  padding: 18px 20px;
   box-shadow: var(--shadow-xs);
-  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition);
+  display: grid;
+  gap: 6px;
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
 }
 
-.exercise-card strong { font-size: 1rem; }
-.exercise-card span { color: var(--muted); font-size: .92rem; }
+.exercise-card strong { font-size: 1.02rem; }
+.exercise-card span { font-size: .92rem; color: var(--muted); }
 
 .exercise-card:not(.is-disabled):hover {
-  transform: translateY(-2px);
+  transform: translateY(-3px);
+  border-color: rgba(91, 108, 255, .32);
   box-shadow: var(--shadow-sm);
-  border-color: rgba(111, 79, 59, 0.24);
+}
+.exercise-card:not(.is-disabled):active { transform: translateY(0) scale(.988); }
+.exercise-card.is-disabled { opacity: .52; cursor: not-allowed; }
+
+.exercise-screen {
+  display: grid;
+  align-content: stretch;
+  gap: 14px;
+  min-height: 100%;
 }
 
-.exercise-card:not(.is-disabled):active { transform: translateY(0) scale(0.99); }
-.exercise-card.is-disabled { opacity: .56; cursor: not-allowed; }
+.app.is-exercise-view {
+  width: min(100% - 16px, 1240px);
+  margin: 8px auto;
+  min-height: calc(100dvh - 16px);
+}
 
-.exercise-screen { gap: 18px; }
+.app.is-exercise-view .exercise-screen {
+  min-height: calc(100dvh - 16px);
+}
+
+.app-header { padding-bottom: 18px; }
 .header-top-row { display: flex; align-items: center; gap: 12px; margin-bottom: 6px; }
 
-.back-btn,
-.level-btn,
-.mode-btn,
-.secondary-btn {
-  border: 1px solid var(--line-soft);
-  background: #fff;
+.back-btn, .level-btn, .mode-btn, .secondary-btn {
+  border: 1px solid var(--line);
   border-radius: 999px;
+  background: #fff;
+  color: var(--text);
+  font-weight: 700;
   min-height: 42px;
   padding: 0 16px;
-  font-weight: 800;
-  color: var(--text);
-  transition: transform 160ms ease, box-shadow var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
+  transition: transform 140ms ease, background var(--transition), border-color var(--transition), box-shadow var(--transition), color var(--transition);
 }
 
-.back-btn:hover,
-.level-btn:hover,
-.mode-btn:hover,
-.secondary-btn:hover {
+.back-btn:hover, .level-btn:hover, .mode-btn:hover, .secondary-btn:hover {
+  border-color: rgba(91, 108, 255, .35);
   box-shadow: var(--shadow-xs);
-  border-color: rgba(111, 79, 59, 0.26);
 }
 
-.back-btn:active,
-.level-btn:active,
-.mode-btn:active,
-.secondary-btn:active { transform: scale(0.98); }
+.back-btn:active, .level-btn:active, .mode-btn:active, .secondary-btn:active { transform: scale(.97); }
+
+.exercise-panel {
+  display: grid;
+  grid-template-rows: auto auto 1fr auto auto;
+  gap: 12px;
+  min-height: 0;
+}
 
 .exercise-top {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 14px;
-  margin-bottom: 2px;
+  gap: 12px;
 }
 
 .score-box {
-  background: linear-gradient(180deg, #f8f4ee, #f2ebe2);
-  border: 1px solid var(--line-soft);
-  border-radius: 16px;
-  padding: 9px 15px;
+  background: var(--surface-soft);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 10px 14px;
+  min-width: 90px;
   text-align: center;
-  min-width: 92px;
 }
 
-.level-tabs,
-.mode-tabs {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
+.level-tabs, .mode-tabs { display: flex; gap: 8px; flex-wrap: wrap; }
+.level-tabs { margin-top: 4px; }
+.mode-tabs { margin-bottom: 6px; }
 
-.level-tabs { margin: 18px 0 10px; }
-.mode-tabs { margin: 0 0 20px; }
-
-.level-btn.is-active,
-.mode-btn.is-active {
-  background: linear-gradient(180deg, var(--accent-2), var(--accent));
+.level-btn.is-active, .mode-btn.is-active {
+  background: linear-gradient(180deg, #6e7cff, var(--accent));
   border-color: transparent;
   color: #fff;
-  box-shadow: 0 8px 16px rgba(95, 68, 53, 0.28);
+  box-shadow: 0 10px 24px rgba(91, 108, 255, .34);
 }
 
-.mode-btn[disabled] { opacity: .5; cursor: not-allowed; }
-.exercise-container { display: grid; gap: 16px; }
+.mode-btn[disabled] { opacity: .54; cursor: not-allowed; }
+.exercise-container { display: grid; gap: 16px; min-height: 0; }
 
 .pieces-cloud {
   position: relative;
-  min-height: clamp(260px, 44vw, 320px);
-  border: 1px dashed rgba(111, 79, 59, 0.3);
-  border-radius: 24px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(252, 247, 241, 0.8));
-  padding: 8px;
+  min-height: clamp(320px, 56vh, 480px);
+  border: 1px solid #d7def6;
+  border-radius: 26px;
+  background: linear-gradient(180deg, #f9faff, #f3f6ff);
+  padding: 10px;
 }
 
 .syllable-piece {
   position: absolute;
-  min-width: clamp(82px, 13vw, 108px);
-  min-height: 56px;
-  padding: 14px 18px;
-  border-radius: 18px;
-  border: 1px solid var(--line-soft);
-  background: linear-gradient(180deg, #ffffff, #fdf8f2);
-  box-shadow: var(--shadow-sm);
-  font-size: clamp(1rem, 2.4vw, 1.24rem);
-  font-weight: 900;
+  min-width: clamp(94px, 13vw, 124px);
+  min-height: clamp(62px, 8vh, 78px);
+  padding: 15px 20px;
+  border-radius: 20px;
+  border: 1px solid #d9dff8;
+  background: #fff;
+  box-shadow: 0 10px 24px rgba(60, 80, 166, 0.17);
+  font-size: clamp(1.06rem, 2.2vw, 1.3rem);
+  font-weight: 800;
+  color: #303868;
   letter-spacing: .01em;
-  color: #30261f;
   transform-origin: center;
-  transition: transform 170ms ease, box-shadow var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
+  transition: transform 140ms ease, box-shadow var(--transition), border-color var(--transition), filter var(--transition);
 }
 
 .syllable-piece:hover {
-  transform: translateY(-1px);
-  border-color: rgba(111, 79, 59, 0.26);
+  transform: translateY(-2px);
+  border-color: rgba(91, 108, 255, .45);
   box-shadow: var(--shadow-md);
 }
+.syllable-piece:active { transform: scale(.95); }
 
-.syllable-piece:active { transform: scale(0.96); }
-
-.slot-a { top: 12%; left: 8%; }
-.slot-b { top: 11%; left: 33%; }
-.slot-c { top: 37%; left: 20%; }
-.slot-d { top: 56%; left: 56%; }
-.slot-e { top: 19%; left: 60%; }
-.slot-f { top: 62%; left: 9%; }
+.slot-a { top: 10%; left: 7%; }
+.slot-b { top: 11%; left: 35%; }
+.slot-c { top: 39%; left: 18%; }
+.slot-d { top: 60%; left: 58%; }
+.slot-e { top: 19%; left: 62%; }
+.slot-f { top: 64%; left: 8%; }
 
 .syllable-piece.is-correct {
-  animation: pulse 300ms ease;
-  border-color: rgba(47, 125, 70, 0.42);
-  box-shadow: 0 0 0 6px rgba(47, 125, 70, 0.08), var(--shadow-sm);
+  animation: pulse 280ms ease;
+  border-color: rgba(38, 162, 105, .5);
+  box-shadow: 0 0 0 6px rgba(38, 162, 105, .14), 0 14px 28px rgba(43, 125, 92, .26);
 }
 
 .syllable-piece.is-wrong {
-  animation: shake 320ms cubic-bezier(.36, .07, .19, .97);
-  border-color: rgba(191, 71, 71, 0.58);
-  background: linear-gradient(180deg, #fff, #fff5f5);
+  animation: shakeSoft 340ms cubic-bezier(.23, 1, .32, 1);
+  border-color: rgba(222, 90, 105, .55);
+  box-shadow: 0 0 0 6px rgba(222, 90, 105, .12), 0 12px 20px rgba(222, 90, 105, .16);
   color: var(--error);
 }
 
 .answer-zone {
-  background: linear-gradient(180deg, #f8f4ee, #f2ebe2);
-  border: 1px solid var(--line-soft);
+  background: var(--surface-soft);
+  border: 1px solid var(--line);
   border-radius: 20px;
-  padding: 15px;
+  padding: 16px;
 }
 
-.answer-zone__label { margin: 0 0 12px; font-weight: 800; color: var(--muted); }
-.answer-slots { display: flex; gap: 11px; flex-wrap: wrap; }
+.answer-zone__label { margin: 0 0 12px; color: var(--muted); font-weight: 700; }
+.answer-slots { display: flex; gap: 12px; flex-wrap: wrap; }
 
 .answer-slot {
-  min-width: clamp(64px, 17vw, 84px);
-  min-height: 58px;
+  min-width: clamp(72px, 16vw, 94px);
+  min-height: 60px;
   display: grid;
   place-items: center;
   background: #fff;
-  border: 1px solid var(--line-soft);
-  border-radius: 14px;
-  font-size: clamp(1rem, 2.4vw, 1.15rem);
-  font-weight: 900;
-  box-shadow: inset 0 -3px 0 rgba(111, 79, 59, 0.06);
-  transition: transform 180ms ease, border-color var(--transition), box-shadow var(--transition);
+  border: 1px solid #dbe1f8;
+  border-radius: 15px;
+  font-size: clamp(1.03rem, 2.2vw, 1.22rem);
+  font-weight: 800;
+  box-shadow: inset 0 -4px 0 rgba(91, 108, 255, .08);
+}
+
+.actions { display: flex; justify-content: flex-end; }
+
+.secondary-btn {
+  background: linear-gradient(180deg, #6e7cff, var(--accent));
+  border-color: transparent;
+  color: #fff;
+  box-shadow: 0 10px 22px rgba(91, 108, 255, .3);
 }
 
 .feedback {
   min-height: 28px;
-  margin: 14px 0 0;
+  margin: 2px 0 0;
   padding: 10px 12px;
   border-radius: 12px;
-  font-weight: 800;
+  font-weight: 700;
   color: var(--muted);
-  transition: background var(--transition), color var(--transition), box-shadow var(--transition), transform var(--transition);
+  transition: all var(--transition);
 }
 
 .feedback.is-success {
-  color: var(--success);
-  background: rgba(47, 125, 70, 0.1);
-  box-shadow: 0 0 0 1px rgba(47, 125, 70, 0.2) inset;
+  color: #1b8d59;
+  background: rgba(38, 162, 105, .11);
+  box-shadow: inset 0 0 0 1px rgba(38, 162, 105, .25), 0 0 20px rgba(38, 162, 105, .12);
 }
 
 .feedback.is-error {
-  color: var(--error);
-  background: rgba(191, 71, 71, 0.09);
-  box-shadow: 0 0 0 1px rgba(191, 71, 71, 0.2) inset;
+  color: #c34454;
+  background: rgba(222, 90, 105, .1);
+  box-shadow: inset 0 0 0 1px rgba(222, 90, 105, .24);
 }
 
-@keyframes shake {
-  20% { transform: translateX(-3px); }
-  40% { transform: translateX(4px); }
+@keyframes shakeSoft {
+  20% { transform: translateX(-2px); }
+  40% { transform: translateX(3px); }
   60% { transform: translateX(-2px); }
   80% { transform: translateX(2px); }
   100% { transform: translateX(0); }
 }
 
 @keyframes pulse {
-  45% { transform: scale(1.05); }
+  40% { transform: scale(1.04); }
   100% { transform: scale(1); }
 }
 
 button:focus-visible {
-  outline: 3px solid #2f75f3;
+  outline: 3px solid rgba(91, 108, 255, .7);
   outline-offset: 2px;
 }
 
-.exercise-card,
-.level-btn,
-.mode-btn,
-.secondary-btn,
-.back-btn,
-.syllable-piece { cursor: pointer; }
+.exercise-card, .level-btn, .mode-btn, .secondary-btn, .back-btn, .syllable-piece { cursor: pointer; }
 
 @media (max-width: 860px) {
-  .app { width: min(100% - 22px, 940px); margin: 18px auto; min-height: calc(100dvh - 36px); }
+  .app { width: min(100% - 20px, 1024px); margin: 14px auto; min-height: calc(100dvh - 28px); }
+  .app.is-exercise-view { width: min(100% - 8px, 1024px); margin: 4px auto; min-height: calc(100dvh - 8px); }
 }
 
 @media (max-width: 640px) {
   .panel { border-radius: 22px; padding: 16px; }
-  .home-screen, .exercise-screen { gap: 14px; }
-  .header-top-row { align-items: flex-start; }
-  .exercise-top { align-items: flex-start; }
-  .score-box { min-width: 84px; }
+  .header-top-row, .exercise-top { align-items: flex-start; }
+  .exercise-panel { grid-template-rows: auto auto auto 1fr auto auto; }
+  .pieces-cloud { min-height: clamp(300px, 54vh, 420px); }
 }


### PR DESCRIPTION
### Motivation
- Dar una identidad visual moderna, táctil y coherente a la app sin alterar la lógica del ejercicio ni los datos.
- Crear una separación visual clara entre `Home` y `Actividad` para que la portada se sienta como plataforma y la actividad como modo inmersivo.
- Mantener las restricciones del proyecto: no cambiar datasets, filtros, arquitectura de motor, ni añadir backend, y conservar JavaScript vanilla y responsive.

### Description
- Reescribí la capa visual en `style.css` para aplicar la nueva paleta (fondo claro cálido `#F6F7FB`, superficies blancas, accent azul-violeta `#5B6CFF`), tipografía `Poppins`, y un sistema de sombras/radios/espaciado más moderno.
- Ajusté componentes y layout para una experiencia diferenciada: `home` más estrecha y aireada, `exercise` más amplia/inmersiva y cercana a `100dvh`, con cards y sílabas rediseñadas (tamaños, radios, sombras, microinteracciones y feedback visual mejorado).
- Mejoré feedback visual de acierto/error: glow más limpio en correcto y `shake` más suave (nueva animación `shakeSoft`) manteniendo la misma lógica funcional.
- Añadí clases de estado en el root desde el router en `src/navigation/router.js` (`is-home-view` / `is-exercise-view`) para permitir ajustes de layout/contexto sin tocar la lógica de navegación ni el motor del ejercicio.

### Testing
- Ejecuté un chequeo rápido de entorno con `node -e "console.log('node ok')"` que se ejecutó correctamente en este entorno.
- Intenté ejecutar `npx --yes playwright --version` como verificación adicional de infraestructura pero falló por restricciones de acceso al registro npm (403), por lo que no se pudieron ejecutar pruebas E2E aquí.
- No se modificaron ni ejecutaron tests automatizados del dominio del juego y no se cambiaron datasets ni lógica de negocio, por lo que la cobertura funcional existente permanece intacta.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0af18b79b4832daba32b6eb3f337a7)