### PR TITLE
Rediseño modo juego para la pantalla de "Ordenar sílabas"

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
           <p class="eyebrow">Ejercicio base de plataforma</p>
         </div>
         <h1>Ordenar sílabas</h1>
-        <p class="subtitle">Toca las sílabas en orden para construir la palabra.</p>
+        <p class="subtitle">¡Modo juego activado! Elige las sílabas gigantes en el tablero para formar cada palabra.</p>
       </header>
 
       <main class="panel exercise-panel">

--- a/style.css
+++ b/style.css
@@ -188,44 +188,52 @@ h2 { font-size: clamp(1.22rem, 2.2vw, 1.65rem); }
 
 .pieces-cloud {
   position: relative;
-  min-height: clamp(260px, 44vw, 320px);
-  border: 1px dashed rgba(111, 79, 59, 0.3);
-  border-radius: 24px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(252, 247, 241, 0.8));
-  padding: 8px;
+  min-height: clamp(320px, 56vw, 470px);
+  border: 2px solid rgba(118, 79, 41, 0.32);
+  border-radius: 34px;
+  background:
+    radial-gradient(170px 95px at 16% 16%, rgba(255, 255, 255, 0.72), transparent 70%),
+    radial-gradient(180px 85px at 82% 20%, rgba(255, 255, 255, 0.68), transparent 68%),
+    linear-gradient(180deg, #fff4cc 0%, #f8d88c 100%);
+  padding: 14px;
+  box-shadow: inset 0 -12px 22px rgba(145, 95, 40, 0.18), 0 18px 34px rgba(97, 58, 21, 0.16);
 }
 
 .syllable-piece {
   position: absolute;
-  min-width: clamp(82px, 13vw, 108px);
-  min-height: 56px;
-  padding: 14px 18px;
-  border-radius: 18px;
-  border: 1px solid var(--line-soft);
-  background: linear-gradient(180deg, #ffffff, #fdf8f2);
-  box-shadow: var(--shadow-sm);
-  font-size: clamp(1rem, 2.4vw, 1.24rem);
+  min-width: clamp(112px, 18vw, 170px);
+  min-height: clamp(76px, 9vw, 92px);
+  padding: 16px 20px;
+  border-radius: 22px;
+  border: 2px solid #8d552e;
+  background: linear-gradient(180deg, #fffcf2, #fff3d1);
+  box-shadow: 0 10px 0 #c57f40, 0 16px 24px rgba(84, 50, 17, 0.2);
+  font-size: clamp(1.35rem, 4.1vw, 2rem);
   font-weight: 900;
-  letter-spacing: .01em;
-  color: #30261f;
+  letter-spacing: .03em;
+  color: #452710;
+  text-transform: uppercase;
   transform-origin: center;
   transition: transform 170ms ease, box-shadow var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
 }
 
 .syllable-piece:hover {
-  transform: translateY(-1px);
-  border-color: rgba(111, 79, 59, 0.26);
-  box-shadow: var(--shadow-md);
+  transform: translateY(-4px) scale(1.02);
+  border-color: #7a421f;
+  box-shadow: 0 12px 0 #b46f33, 0 18px 26px rgba(84, 50, 17, 0.26);
 }
 
-.syllable-piece:active { transform: scale(0.96); }
+.syllable-piece:active {
+  transform: translateY(6px) scale(0.98);
+  box-shadow: 0 4px 0 #b46f33, 0 10px 18px rgba(84, 50, 17, 0.2);
+}
 
-.slot-a { top: 12%; left: 8%; }
-.slot-b { top: 11%; left: 33%; }
-.slot-c { top: 37%; left: 20%; }
-.slot-d { top: 56%; left: 56%; }
-.slot-e { top: 19%; left: 60%; }
-.slot-f { top: 62%; left: 9%; }
+.slot-a { top: 10%; left: 8%; }
+.slot-b { top: 12%; left: 39%; }
+.slot-c { top: 40%; left: 15%; }
+.slot-d { top: 62%; left: 55%; }
+.slot-e { top: 28%; left: 61%; }
+.slot-f { top: 68%; left: 8%; }
 
 .syllable-piece.is-correct {
   animation: pulse 300ms ease;
@@ -241,26 +249,28 @@ h2 { font-size: clamp(1.22rem, 2.2vw, 1.65rem); }
 }
 
 .answer-zone {
-  background: linear-gradient(180deg, #f8f4ee, #f2ebe2);
-  border: 1px solid var(--line-soft);
-  border-radius: 20px;
-  padding: 15px;
+  background: linear-gradient(180deg, #ffffff, #f9f1e4);
+  border: 2px solid rgba(136, 83, 37, 0.24);
+  border-radius: 24px;
+  padding: 18px;
+  box-shadow: inset 0 -4px 0 rgba(142, 90, 43, 0.08);
 }
 
-.answer-zone__label { margin: 0 0 12px; font-weight: 800; color: var(--muted); }
+.answer-zone__label { margin: 0 0 12px; font-weight: 900; color: #72431f; font-size: 1.02rem; }
 .answer-slots { display: flex; gap: 11px; flex-wrap: wrap; }
 
 .answer-slot {
-  min-width: clamp(64px, 17vw, 84px);
-  min-height: 58px;
+  min-width: clamp(88px, 18vw, 116px);
+  min-height: clamp(64px, 9vw, 84px);
   display: grid;
   place-items: center;
-  background: #fff;
-  border: 1px solid var(--line-soft);
-  border-radius: 14px;
-  font-size: clamp(1rem, 2.4vw, 1.15rem);
+  background: linear-gradient(180deg, #fffef8, #fff5dc);
+  border: 2px dashed rgba(137, 88, 44, 0.52);
+  border-radius: 18px;
+  font-size: clamp(1.15rem, 3.5vw, 1.45rem);
   font-weight: 900;
-  box-shadow: inset 0 -3px 0 rgba(111, 79, 59, 0.06);
+  color: #5c3416;
+  box-shadow: inset 0 -4px 0 rgba(111, 79, 59, 0.08);
   transition: transform 180ms ease, border-color var(--transition), box-shadow var(--transition);
 }
 


### PR DESCRIPTION
### Motivation
- Sustituir la estética tipo "chat" por una interfaz más lúdica y accesible para el ejercicio de Ordenar sílabas. 
- Hacer las fichas de sílabas y el área de selección mucho más grandes para facilitar la interacción táctil y visual.

### Description
- Actualicé `style.css` para transformar el tablero (`.pieces-cloud`) con fondo tipo tablero, mayor altura, bordes más marcados, sombras y padding aumentado. 
- Redimensioné y estilicé las fichas (`.syllable-piece`) para que sean significativamente más grandes, con bordes, sombras y comportamiento `hover`/`active` tipo botón de juego, además de texto en mayúsculas. 
- Reubicadas las clases de posición (`.slot-a` … `.slot-f`) para mejorar la distribución visual de las sílabas dentro del tablero. 
- Rediseñé la zona de respuesta (`.answer-zone` y `.answer-slot`) y actualicé el subtítulo en `index.html` para indicar el nuevo enfoque "modo juego".

### Testing
- Inspeccioné los cambios en archivos con `nl -ba style.css | sed -n '150,340p'` y `nl -ba index.html | sed -n '30,70p'`, y verificaron las modificaciones esperadas (éxito). 
- Intenté levantar un servidor local y tomar una captura con `chromium --headless` pero no hay navegador headless disponible en el entorno (falló). 
- Intenté generar una captura con Playwright usando `npx playwright screenshot` pero la instalación falló por restricción del registro (`403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b127a7cb0832da302515fe5cb0bcb)