### PR TITLE
Rediseño visual fullscreen para ejercicio 'Ordenar sílabas'

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,48 +29,44 @@
       </nav>
     </section>
 
-    <section id="exercise-screen" class="view exercise-screen">
-      <header class="app-header panel">
-        <div class="header-top-row">
-          <button id="home-btn" class="back-btn" type="button" aria-label="Volver a la portada">Volver</button>
-          <p class="eyebrow">Ejercicio base de plataforma</p>
+    <section id="exercise-screen" class="view exercise-screen" aria-label="Actividad ordenar sílabas">
+      <header class="activity-topbar">
+        <button id="home-btn" class="back-btn" type="button" aria-label="Volver a la portada">Salir</button>
+
+        <div class="top-meta">
+          <p class="eyebrow" id="level-label">Nivel 1</p>
+          <h2 id="round-word">2 sílabas</h2>
         </div>
-        <h1>Ordenar sílabas</h1>
-        <p class="subtitle">Toca las sílabas en orden para construir la palabra.</p>
-      </header>
 
-      <main class="panel exercise-panel">
-        <div class="exercise-top">
-          <div>
-            <p class="eyebrow" id="level-label">Nivel 1</p>
-            <h2 id="round-word">2 sílabas</h2>
+        <div class="top-controls">
+          <div class="mode-tabs" aria-label="Selector de modo">
+            <button class="mode-btn is-active" data-mode="normal">Normal</button>
+            <button class="mode-btn" data-mode="intruders" disabled title="Próximamente">Intrusos</button>
           </div>
-
-          <div class="score-box">
+          <div class="score-box" aria-label="Aciertos acumulados">
             <span>Aciertos</span>
             <strong id="score">0</strong>
           </div>
         </div>
+      </header>
 
-        <div class="level-tabs">
+      <main class="activity-stage">
+        <div id="exercise-container" class="exercise-container"></div>
+      </main>
+
+      <footer class="activity-footer">
+        <div class="level-tabs" aria-label="Selector de nivel">
           <button class="level-btn is-active" data-level="1">Nivel 1</button>
           <button class="level-btn" data-level="2">Nivel 2</button>
           <button class="level-btn" data-level="3">Nivel 3</button>
         </div>
 
-        <div class="mode-tabs" aria-label="Selector de modo">
-          <button class="mode-btn is-active" data-mode="normal">Normal</button>
-          <button class="mode-btn" data-mode="intruders" disabled title="Próximamente">Intrusos</button>
-        </div>
-
-        <div id="exercise-container" class="exercise-container"></div>
-
-        <div class="actions">
+        <div class="footer-actions">
           <button id="next-btn" class="secondary-btn">Nueva palabra</button>
         </div>
 
         <p id="feedback" class="feedback" aria-live="polite"></p>
-      </main>
+      </footer>
     </section>
   </div>
 

--- a/main.js
+++ b/main.js
@@ -176,6 +176,7 @@ function openExercise(exerciseId) {
 
   state.activeExerciseId = exerciseId;
   router.navigateExercise();
+  document.body.classList.add('is-activity-mode');
   refs.score.textContent = '0';
   plugin.start({ level: 1, mode: 'normal', resetScore: true });
   setLevel(1);
@@ -205,10 +206,12 @@ function init() {
 
   refs.homeBtn.addEventListener('click', () => {
     router.navigateHome();
+    document.body.classList.remove('is-activity-mode');
     setFeedback('');
   });
 
   router.init('home');
+  document.body.classList.remove('is-activity-mode');
 }
 
 init();

--- a/style.css
+++ b/style.css
@@ -31,6 +31,11 @@ body {
     radial-gradient(900px 340px at 90% -10%, rgba(255, 255, 255, 0.62), transparent 58%),
     linear-gradient(180deg, var(--bg), var(--bg-2));
   color: var(--text);
+  min-height: 100dvh;
+}
+
+body.is-activity-mode {
+  overflow: hidden;
 }
 
 .app {
@@ -70,56 +75,56 @@ body {
   backdrop-filter: blur(6px);
 }
 
-.eyebrow {
-  margin: 0 0 8px;
-  font-size: .78rem;
-  text-transform: uppercase;
-  letter-spacing: .11em;
-  color: var(--muted);
-  font-weight: 800;
-}
-
+.eyebrow { margin: 0 0 8px; font-size: .78rem; text-transform: uppercase; letter-spacing: .11em; color: var(--muted); font-weight: 800; }
 h1, h2 { margin: 0; line-height: 1.14; letter-spacing: -.01em; }
 h1 { font-size: clamp(1.45rem, 2.6vw, 2rem); }
-h2 { font-size: clamp(1.22rem, 2.2vw, 1.65rem); }
-
-.subtitle {
-  margin: 10px 0 0;
-  color: var(--muted);
-  max-width: 72ch;
-  line-height: 1.5;
-}
+h2 { font-size: clamp(1.05rem, 2vw, 1.32rem); }
+.subtitle { margin: 10px 0 0; color: var(--muted); max-width: 72ch; line-height: 1.5; }
 
 .home-screen { gap: 22px; }
 .exercise-menu { display: grid; gap: 12px; }
-
-.exercise-card {
-  width: 100%;
-  border: 1px solid var(--line-soft);
-  border-radius: 18px;
-  background: linear-gradient(180deg, #fff, #fdfaf7);
-  padding: 16px 18px;
-  text-align: left;
-  display: grid;
-  gap: 5px;
-  box-shadow: var(--shadow-xs);
-  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition);
-}
-
+.exercise-card { width: 100%; border: 1px solid var(--line-soft); border-radius: 18px; background: linear-gradient(180deg, #fff, #fdfaf7); padding: 16px 18px; text-align: left; display: grid; gap: 5px; box-shadow: var(--shadow-xs); transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition); }
 .exercise-card strong { font-size: 1rem; }
 .exercise-card span { color: var(--muted); font-size: .92rem; }
-
-.exercise-card:not(.is-disabled):hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-sm);
-  border-color: rgba(111, 79, 59, 0.24);
-}
-
+.exercise-card:not(.is-disabled):hover { transform: translateY(-2px); box-shadow: var(--shadow-sm); border-color: rgba(111, 79, 59, 0.24); }
 .exercise-card:not(.is-disabled):active { transform: translateY(0) scale(0.99); }
 .exercise-card.is-disabled { opacity: .56; cursor: not-allowed; }
 
-.exercise-screen { gap: 18px; }
-.header-top-row { display: flex; align-items: center; gap: 12px; margin-bottom: 6px; }
+.exercise-screen {
+  inset: -12px;
+  padding: clamp(12px, 2.8vw, 28px);
+  border-radius: 30px;
+  gap: clamp(10px, 1.8vh, 16px);
+  background:
+    radial-gradient(130% 100% at 8% 8%, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0) 50%),
+    linear-gradient(170deg, #f8f4ed 8%, #f1e8dc 50%, #ecdfd1 100%);
+  border: 1px solid rgba(111, 79, 59, 0.18);
+  box-shadow: 0 18px 44px rgba(22, 14, 7, 0.14);
+  min-height: 100%;
+  grid-template-rows: auto 1fr auto;
+  overflow: hidden;
+}
+
+.activity-topbar,
+.activity-footer {
+  background: rgba(255, 255, 255, 0.68);
+  border: 1px solid rgba(111, 79, 59, 0.14);
+  border-radius: 20px;
+  backdrop-filter: blur(7px);
+}
+
+.activity-topbar {
+  min-height: clamp(72px, 10vh, 92px);
+  display: grid;
+  grid-template-columns: auto minmax(150px, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 10px clamp(12px, 2.5vw, 18px);
+}
+
+.top-meta .eyebrow { margin-bottom: 2px; }
+.top-meta h2 { margin: 0; }
+.top-controls { display: flex; align-items: center; gap: 10px; }
 
 .back-btn,
 .level-btn,
@@ -135,190 +140,117 @@ h2 { font-size: clamp(1.22rem, 2.2vw, 1.65rem); }
   transition: transform 160ms ease, box-shadow var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
 }
 
-.back-btn:hover,
-.level-btn:hover,
-.mode-btn:hover,
-.secondary-btn:hover {
-  box-shadow: var(--shadow-xs);
-  border-color: rgba(111, 79, 59, 0.26);
-}
-
-.back-btn:active,
-.level-btn:active,
-.mode-btn:active,
-.secondary-btn:active { transform: scale(0.98); }
-
-.exercise-top {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 14px;
-  margin-bottom: 2px;
-}
-
 .score-box {
   background: linear-gradient(180deg, #f8f4ee, #f2ebe2);
   border: 1px solid var(--line-soft);
-  border-radius: 16px;
-  padding: 9px 15px;
-  text-align: center;
-  min-width: 92px;
+  border-radius: 999px;
+  padding: 8px 13px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
 }
 
 .level-tabs,
-.mode-tabs {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.level-tabs { margin: 18px 0 10px; }
-.mode-tabs { margin: 0 0 20px; }
-
+.mode-tabs { display: flex; gap: 8px; flex-wrap: wrap; }
 .level-btn.is-active,
-.mode-btn.is-active {
-  background: linear-gradient(180deg, var(--accent-2), var(--accent));
-  border-color: transparent;
-  color: #fff;
-  box-shadow: 0 8px 16px rgba(95, 68, 53, 0.28);
+.mode-btn.is-active { background: linear-gradient(180deg, var(--accent-2), var(--accent)); border-color: transparent; color: #fff; box-shadow: 0 8px 16px rgba(95, 68, 53, 0.28); }
+.mode-btn[disabled] { opacity: .5; cursor: not-allowed; }
+
+.activity-stage {
+  min-height: 0;
+  overflow: hidden;
 }
 
-.mode-btn[disabled] { opacity: .5; cursor: not-allowed; }
-.exercise-container { display: grid; gap: 16px; }
+.exercise-container,
+.pieces-cloud {
+  height: 100%;
+}
+
+.exercise-container {
+  display: grid;
+  grid-template-rows: 1fr auto;
+  gap: clamp(10px, 2vh, 18px);
+}
 
 .pieces-cloud {
   position: relative;
-  min-height: clamp(260px, 44vw, 320px);
-  border: 1px dashed rgba(111, 79, 59, 0.3);
-  border-radius: 24px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(252, 247, 241, 0.8));
-  padding: 8px;
+  min-height: 0;
+  border-radius: 28px;
+  background: radial-gradient(120% 120% at 20% 15%, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.32));
+  border: 1px solid rgba(111, 79, 59, 0.17);
+  box-shadow: inset 0 -2px 0 rgba(111, 79, 59, 0.1);
 }
 
 .syllable-piece {
   position: absolute;
-  min-width: clamp(82px, 13vw, 108px);
-  min-height: 56px;
-  padding: 14px 18px;
-  border-radius: 18px;
-  border: 1px solid var(--line-soft);
-  background: linear-gradient(180deg, #ffffff, #fdf8f2);
-  box-shadow: var(--shadow-sm);
-  font-size: clamp(1rem, 2.4vw, 1.24rem);
+  min-width: clamp(108px, 18vw, 180px);
+  min-height: clamp(72px, 10vh, 96px);
+  padding: clamp(12px, 2vh, 18px) clamp(20px, 2.7vw, 28px);
+  border-radius: 999px;
+  border: 1px solid rgba(111, 79, 59, 0.2);
+  background: linear-gradient(180deg, #fffefb, #fff8ef);
+  box-shadow: 0 12px 18px rgba(32, 20, 12, 0.12), inset 0 -3px 0 rgba(111, 79, 59, 0.08);
+  font-size: clamp(1.3rem, 3.8vw, 2.1rem);
   font-weight: 900;
-  letter-spacing: .01em;
+  letter-spacing: .02em;
   color: #30261f;
   transform-origin: center;
-  transition: transform 170ms ease, box-shadow var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
+  transition: transform 150ms ease, box-shadow var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
 }
 
-.syllable-piece:hover {
-  transform: translateY(-1px);
-  border-color: rgba(111, 79, 59, 0.26);
-  box-shadow: var(--shadow-md);
-}
+.syllable-piece:hover { transform: translateY(-2px) scale(1.015); box-shadow: 0 16px 24px rgba(32, 20, 12, 0.16); }
+.syllable-piece:active { transform: scale(0.94); }
 
-.syllable-piece:active { transform: scale(0.96); }
-
-.slot-a { top: 12%; left: 8%; }
-.slot-b { top: 11%; left: 33%; }
-.slot-c { top: 37%; left: 20%; }
-.slot-d { top: 56%; left: 56%; }
-.slot-e { top: 19%; left: 60%; }
-.slot-f { top: 62%; left: 9%; }
-
-.syllable-piece.is-correct {
-  animation: pulse 300ms ease;
-  border-color: rgba(47, 125, 70, 0.42);
-  box-shadow: 0 0 0 6px rgba(47, 125, 70, 0.08), var(--shadow-sm);
-}
-
-.syllable-piece.is-wrong {
-  animation: shake 320ms cubic-bezier(.36, .07, .19, .97);
-  border-color: rgba(191, 71, 71, 0.58);
-  background: linear-gradient(180deg, #fff, #fff5f5);
-  color: var(--error);
-}
+.slot-a { top: 9%; left: 8%; }
+.slot-b { top: 12%; left: 34%; }
+.slot-c { top: 37%; left: 18%; }
+.slot-d { top: 58%; left: 55%; }
+.slot-e { top: 24%; left: 61%; }
+.slot-f { top: 63%; left: 8%; }
 
 .answer-zone {
-  background: linear-gradient(180deg, #f8f4ee, #f2ebe2);
-  border: 1px solid var(--line-soft);
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(111, 79, 59, 0.16);
   border-radius: 20px;
-  padding: 15px;
+  padding: clamp(12px, 2vw, 16px);
 }
+.answer-zone__label { margin: 0 0 9px; font-weight: 800; color: var(--muted); }
+.answer-slots { display: flex; gap: 10px; flex-wrap: wrap; }
+.answer-slot { min-width: clamp(68px, 13vw, 100px); min-height: clamp(60px, 8vh, 76px); display: grid; place-items: center; background: #fff; border: 1px solid var(--line-soft); border-radius: 14px; font-size: clamp(1.2rem, 2.8vw, 1.6rem); font-weight: 900; box-shadow: inset 0 -3px 0 rgba(111, 79, 59, 0.06); }
 
-.answer-zone__label { margin: 0 0 12px; font-weight: 800; color: var(--muted); }
-.answer-slots { display: flex; gap: 11px; flex-wrap: wrap; }
-
-.answer-slot {
-  min-width: clamp(64px, 17vw, 84px);
-  min-height: 58px;
+.activity-footer {
+  padding: 10px clamp(12px, 2.5vw, 18px);
   display: grid;
-  place-items: center;
-  background: #fff;
-  border: 1px solid var(--line-soft);
-  border-radius: 14px;
-  font-size: clamp(1rem, 2.4vw, 1.15rem);
-  font-weight: 900;
-  box-shadow: inset 0 -3px 0 rgba(111, 79, 59, 0.06);
-  transition: transform 180ms ease, border-color var(--transition), box-shadow var(--transition);
+  gap: 8px;
 }
+.footer-actions { justify-self: end; }
+.feedback { min-height: 24px; margin: 0; padding: 8px 10px; border-radius: 10px; font-weight: 800; color: var(--muted); }
+.feedback.is-success { color: var(--success); background: rgba(47, 125, 70, 0.1); box-shadow: 0 0 0 1px rgba(47, 125, 70, 0.2) inset; }
+.feedback.is-error { color: var(--error); background: rgba(191, 71, 71, 0.09); box-shadow: 0 0 0 1px rgba(191, 71, 71, 0.2) inset; }
 
-.feedback {
-  min-height: 28px;
-  margin: 14px 0 0;
-  padding: 10px 12px;
-  border-radius: 12px;
-  font-weight: 800;
-  color: var(--muted);
-  transition: background var(--transition), color var(--transition), box-shadow var(--transition), transform var(--transition);
-}
+.syllable-piece.is-correct { animation: pulse 300ms ease; border-color: rgba(47, 125, 70, 0.42); box-shadow: 0 0 0 6px rgba(47, 125, 70, 0.08), 0 12px 18px rgba(32, 20, 12, 0.12); }
+.syllable-piece.is-wrong { animation: shake 320ms cubic-bezier(.36, .07, .19, .97); border-color: rgba(191, 71, 71, 0.58); background: linear-gradient(180deg, #fff, #fff5f5); color: var(--error); }
 
-.feedback.is-success {
-  color: var(--success);
-  background: rgba(47, 125, 70, 0.1);
-  box-shadow: 0 0 0 1px rgba(47, 125, 70, 0.2) inset;
-}
+@keyframes shake { 20% { transform: translateX(-3px); } 40% { transform: translateX(4px); } 60% { transform: translateX(-2px); } 80% { transform: translateX(2px); } 100% { transform: translateX(0); } }
+@keyframes pulse { 45% { transform: scale(1.05); } 100% { transform: scale(1); } }
 
-.feedback.is-error {
-  color: var(--error);
-  background: rgba(191, 71, 71, 0.09);
-  box-shadow: 0 0 0 1px rgba(191, 71, 71, 0.2) inset;
-}
-
-@keyframes shake {
-  20% { transform: translateX(-3px); }
-  40% { transform: translateX(4px); }
-  60% { transform: translateX(-2px); }
-  80% { transform: translateX(2px); }
-  100% { transform: translateX(0); }
-}
-
-@keyframes pulse {
-  45% { transform: scale(1.05); }
-  100% { transform: scale(1); }
-}
-
-button:focus-visible {
-  outline: 3px solid #2f75f3;
-  outline-offset: 2px;
-}
-
-.exercise-card,
-.level-btn,
-.mode-btn,
-.secondary-btn,
-.back-btn,
-.syllable-piece { cursor: pointer; }
+button:focus-visible { outline: 3px solid #2f75f3; outline-offset: 2px; }
+.exercise-card, .level-btn, .mode-btn, .secondary-btn, .back-btn, .syllable-piece { cursor: pointer; }
 
 @media (max-width: 860px) {
-  .app { width: min(100% - 22px, 940px); margin: 18px auto; min-height: calc(100dvh - 36px); }
+  .app { width: 100%; margin: 0; min-height: 100dvh; }
+  .home-screen.panel { margin: 12px; min-height: calc(100dvh - 24px); }
+  .exercise-screen { inset: 0; border-radius: 0; border: 0; }
 }
 
 @media (max-width: 640px) {
-  .panel { border-radius: 22px; padding: 16px; }
-  .home-screen, .exercise-screen { gap: 14px; }
-  .header-top-row { align-items: flex-start; }
-  .exercise-top { align-items: flex-start; }
-  .score-box { min-width: 84px; }
+  .activity-topbar { grid-template-columns: auto 1fr; grid-template-areas: "exit meta" "controls controls"; align-items: start; }
+  .back-btn { grid-area: exit; }
+  .top-meta { grid-area: meta; text-align: right; }
+  .top-controls { grid-area: controls; justify-content: space-between; width: 100%; }
+  .mode-tabs { max-width: 68%; }
+  .level-tabs { justify-content: center; }
+  .footer-actions { justify-self: stretch; }
+  .secondary-btn { width: 100%; }
 }


### PR DESCRIPTION
### Motivation
- El ejercicio debía transformarse de una pantalla tipo dashboard a una experiencia de actividad fullscreen, táctil e inmersiva para niños sin tocar la lógica ni los datasets.
- Hay que priorizar la zona central con las sílabas como piezas de juego grandes y flotantes, reducir la sensación de web larga y eliminar el look de cards apiladas.
- Mantener responsive y accesible en móvil/tablet/desktop mientras se conserva todo el flujo de taps, validación y métricas existentes.

### Description
- Reestructura la vista del ejercicio en tres zonas semánticas: `activity-topbar`, `activity-stage` y `activity-footer` para enfatizar top discreto, escenario central y footer de control, moviendo elementos entre `index.html` y la nueva jerarquía visual. 
- Reestilos globales en `style.css` para modo actividad inmersivo: fondo, topbar y footer translúcidos, escenario central sin scroll y nube de sílabas con piezas mucho más grandes, formas más orgánicas, más espacio entre piezas y microinteracciones (hover/active/animaciones). 
- Ajustes responsivos para móvil/tablet/desktop que evitan scroll vertical durante la actividad y recolocan controles (niveles/modos/acciones) en topbar y footer adaptativos. 
- Cambio en `main.js` para aplicar y limpiar la clase `is-activity-mode` en `body` al entrar/salir del ejercicio, sin alterar la lógica del plugin ni los flujos de `start/submit/next`. 

### Testing
- Se ejecutó la comprobación de sintaxis de JavaScript con `node --check main.js` y retornó sin errores. 
- No se modificaron ni ejecutaron tests de negocio o datasets; la lógica del ejercicio se mantiene intacta y la verificación automática disponible fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b134c28e4832d8e2104f340fb03f2)