### PR TITLE
Refine visual design: tactile syllable pieces and immersive exercise board

### DIFF
--- a/style.css
+++ b/style.css
@@ -115,13 +115,42 @@ h2 { font-size: clamp(1.05rem, 2vw, 1.32rem); }
   border-radius: 30px;
   gap: clamp(10px, 1.8vh, 16px);
   background:
-    radial-gradient(130% 100% at 8% 8%, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0) 50%),
-    linear-gradient(170deg, #f8f4ed 8%, #f1e8dc 50%, #ecdfd1 100%);
-  border: 1px solid rgba(111, 79, 59, 0.18);
-  box-shadow: 0 18px 44px rgba(22, 14, 7, 0.14);
+    radial-gradient(88% 90% at 8% 10%, rgba(255, 255, 255, 0.5), transparent 62%),
+    radial-gradient(90% 85% at 92% 16%, rgba(255, 236, 214, 0.34), transparent 66%),
+    linear-gradient(165deg, #f0e6d7 0%, #e9dccb 36%, #e4d6c2 72%, #dfcfbb 100%);
+  border: 1px solid rgba(89, 62, 44, 0.22);
+  box-shadow:
+    0 24px 54px rgba(22, 14, 7, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.45);
   min-height: 100%;
   grid-template-rows: auto 1fr auto;
   overflow: hidden;
+}
+
+.exercise-screen::before,
+.exercise-screen::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+}
+
+.exercise-screen::before {
+  inset: 14px;
+  border-radius: 24px;
+  background-image:
+    linear-gradient(115deg, rgba(255, 255, 255, 0.08) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.08) 50%, rgba(255, 255, 255, 0.08) 75%, transparent 75%, transparent);
+  background-size: 16px 16px;
+  opacity: .22;
+}
+
+.exercise-screen::after {
+  width: 46%;
+  height: 40%;
+  right: -8%;
+  bottom: -12%;
+  border-radius: 999px;
+  background: radial-gradient(circle at center, rgba(255, 223, 173, 0.3), transparent 70%);
+  filter: blur(10px);
 }
 
 .activity-topbar,
@@ -179,6 +208,11 @@ h2 { font-size: clamp(1.05rem, 2vw, 1.32rem); }
 .activity-stage {
   min-height: 0;
   overflow: hidden;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 24px;
+  border: 1px solid rgba(102, 72, 54, 0.15);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  padding: clamp(10px, 1.6vw, 16px);
 }
 
 .exercise-container,
@@ -195,31 +229,62 @@ h2 { font-size: clamp(1.05rem, 2vw, 1.32rem); }
 .pieces-cloud {
   position: relative;
   min-height: 0;
-  border-radius: 28px;
-  background: radial-gradient(120% 120% at 20% 15%, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.32));
-  border: 1px solid rgba(111, 79, 59, 0.17);
-  box-shadow: inset 0 -2px 0 rgba(111, 79, 59, 0.1);
+  border-radius: 30px;
+  background:
+    radial-gradient(120% 100% at 18% 12%, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.28)),
+    linear-gradient(180deg, rgba(255, 252, 246, 0.95), rgba(249, 240, 228, 0.95));
+  border: 1px solid rgba(111, 79, 59, 0.22);
+  box-shadow:
+    inset 0 -2px 0 rgba(111, 79, 59, 0.1),
+    0 14px 30px rgba(28, 17, 9, 0.12);
+}
+
+.pieces-cloud::before {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 22px;
+  border: 1px dashed rgba(111, 79, 59, 0.2);
+  opacity: .38;
+  pointer-events: none;
 }
 
 .syllable-piece {
   position: absolute;
-  min-width: clamp(108px, 18vw, 180px);
-  min-height: clamp(72px, 10vh, 96px);
-  padding: clamp(12px, 2vh, 18px) clamp(20px, 2.7vw, 28px);
-  border-radius: 999px;
-  border: 1px solid rgba(111, 79, 59, 0.2);
-  background: linear-gradient(180deg, #fffefb, #fff8ef);
-  box-shadow: 0 12px 18px rgba(32, 20, 12, 0.12), inset 0 -3px 0 rgba(111, 79, 59, 0.08);
-  font-size: clamp(1.3rem, 3.8vw, 2.1rem);
+  min-width: clamp(124px, 18vw, 196px);
+  min-height: clamp(82px, 10vh, 108px);
+  padding: clamp(14px, 2.1vh, 20px) clamp(24px, 3vw, 34px);
+  border-radius: 30px;
+  border: 1px solid rgba(111, 79, 59, 0.24);
+  background:
+    linear-gradient(178deg, #fffcf8 0%, #fff4e4 58%, #fbe9d1 100%);
+  box-shadow:
+    0 14px 22px rgba(32, 20, 12, 0.16),
+    0 5px 0 rgba(138, 99, 74, 0.24),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  font-size: clamp(1.42rem, 4vw, 2.3rem);
   font-weight: 900;
-  letter-spacing: .02em;
-  color: #30261f;
+  letter-spacing: .03em;
+  color: #2c2119;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
   transform-origin: center;
-  transition: transform 150ms ease, box-shadow var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
+  transition: transform 180ms cubic-bezier(.2, .8, .28, 1.35), box-shadow var(--transition), border-color var(--transition), background var(--transition), color var(--transition), filter var(--transition);
 }
 
-.syllable-piece:hover { transform: translateY(-2px) scale(1.015); box-shadow: 0 16px 24px rgba(32, 20, 12, 0.16); }
-.syllable-piece:active { transform: scale(0.94); }
+.syllable-piece:hover {
+  transform: translateY(-4px) scale(1.024);
+  box-shadow:
+    0 18px 26px rgba(32, 20, 12, 0.18),
+    0 6px 0 rgba(138, 99, 74, 0.2),
+    0 0 0 5px rgba(255, 213, 157, 0.2);
+}
+.syllable-piece:active {
+  transform: translateY(1px) scale(0.965);
+  box-shadow:
+    0 8px 14px rgba(32, 20, 12, 0.16),
+    0 2px 0 rgba(138, 99, 74, 0.22),
+    0 0 0 6px rgba(255, 213, 157, 0.26);
+}
 
 .slot-a { top: 9%; left: 8%; }
 .slot-b { top: 12%; left: 34%; }
@@ -229,14 +294,30 @@ h2 { font-size: clamp(1.05rem, 2vw, 1.32rem); }
 .slot-f { top: 63%; left: 8%; }
 
 .answer-zone {
-  background: rgba(255, 255, 255, 0.72);
-  border: 1px solid rgba(111, 79, 59, 0.16);
-  border-radius: 20px;
-  padding: clamp(12px, 2vw, 16px);
+  background:
+    radial-gradient(120% 100% at 12% 8%, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.66)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(249, 239, 225, 0.9));
+  border: 1px solid rgba(111, 79, 59, 0.24);
+  border-radius: 24px;
+  padding: clamp(14px, 2.2vw, 20px);
+  box-shadow: 0 12px 22px rgba(29, 19, 11, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.65);
 }
-.answer-zone__label { margin: 0 0 9px; font-weight: 800; color: var(--muted); }
-.answer-slots { display: flex; gap: 10px; flex-wrap: wrap; }
-.answer-slot { min-width: clamp(68px, 13vw, 100px); min-height: clamp(60px, 8vh, 76px); display: grid; place-items: center; background: #fff; border: 1px solid var(--line-soft); border-radius: 14px; font-size: clamp(1.2rem, 2.8vw, 1.6rem); font-weight: 900; box-shadow: inset 0 -3px 0 rgba(111, 79, 59, 0.06); }
+.answer-zone__label { margin: 0 0 12px; font-weight: 900; color: #5e4b3f; letter-spacing: .015em; }
+.answer-slots { display: flex; gap: 12px; flex-wrap: wrap; }
+.answer-slot {
+  min-width: clamp(76px, 13vw, 116px);
+  min-height: clamp(66px, 8.5vh, 86px);
+  display: grid;
+  place-items: center;
+  background: linear-gradient(180deg, #fffdf9, #fdf2e2);
+  border: 1px solid rgba(111, 79, 59, 0.22);
+  border-radius: 16px;
+  font-size: clamp(1.3rem, 3vw, 1.9rem);
+  font-weight: 900;
+  color: #2f261f;
+  box-shadow: inset 0 -3px 0 rgba(111, 79, 59, 0.12), 0 8px 14px rgba(25, 16, 10, 0.09);
+  transition: transform var(--transition), box-shadow var(--transition);
+}
 
 .activity-footer {
   padding: 10px clamp(12px, 2.5vw, 18px);
@@ -248,7 +329,7 @@ h2 { font-size: clamp(1.05rem, 2vw, 1.32rem); }
 .feedback.is-success { color: var(--success); background: rgba(47, 125, 70, 0.1); box-shadow: 0 0 0 1px rgba(47, 125, 70, 0.2) inset; }
 .feedback.is-error { color: var(--error); background: rgba(191, 71, 71, 0.09); box-shadow: 0 0 0 1px rgba(191, 71, 71, 0.2) inset; }
 
-.syllable-piece.is-correct { animation: pulse 300ms ease; border-color: rgba(47, 125, 70, 0.42); box-shadow: 0 0 0 6px rgba(47, 125, 70, 0.08), 0 12px 18px rgba(32, 20, 12, 0.12); }
+.syllable-piece.is-correct { animation: pulse 340ms cubic-bezier(.24, .65, .31, 1.2); border-color: rgba(47, 125, 70, 0.42); box-shadow: 0 0 0 7px rgba(47, 125, 70, 0.1), 0 14px 22px rgba(32, 20, 12, 0.14); }
 .syllable-piece.is-wrong { animation: shake 320ms cubic-bezier(.36, .07, .19, .97); border-color: rgba(191, 71, 71, 0.58); background: linear-gradient(180deg, #fff, #fff5f5); color: var(--error); }
 
 @keyframes shake { 20% { transform: translateX(-3px); } 40% { transform: translateX(4px); } 60% { transform: translateX(-2px); } 80% { transform: translateX(2px); } 100% { transform: translateX(0); } }


### PR DESCRIPTION
### Motivation
- Improve the visual identity and tactile feel of the syllable ordering activity so it no longer looks like a wireframe and the game area reads as a distinct, immersive zone.
- Make the syllable pieces feel like physical, tappable game chips and give the constructed-word area stronger hierarchy without altering game logic, data filters, layout or responsiveness.

### Description
- Revamped the fullscreen exercise background with layered gradients and ambient glow and added subtle texture overlays to give the board its own identity (`style.css` changes around `.exercise-screen` and its pseudo-elements). 
- Added soft framing and internal elevation to the activity stage (`.activity-stage`) to reduce empty space and improve visual separation while preserving existing grid/layout behavior.
- Rebuilt `.syllable-piece` visuals: increased size and padding, changed shape and surface gradient, added multi-layer shadows, text-shadow, refined letter-spacing, and updated hover/active microinteractions and transition timing for a more tactile feel.
- Enhanced the pieces container (`.pieces-cloud`) with a richer surface, inner dashed frame and stronger shadowing, and elevated the answer area (`.answer-zone` and `.answer-slot`) with larger, more prominent slots and improved spacing and contrast; adjusted correct/wrong feedback visuals to match the new depth language.
- All edits are confined to CSS; no JS, dataset, filter logic or responsive rules were modified.

### Testing
- No automated test suite was present or executed for this visual-only change.
- Performed repository sanity checks to confirm the CSS file update was applied and the working tree is clean after committing the stylesheet change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b181a37d8832d9a080a55089f24a3)