### PR TITLE
Rediseño: convertir la actividad "Ordenar sílabas" en una escena fullscreen inmersiva

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,22 +31,21 @@
 
     <section id="exercise-screen" class="view exercise-screen" aria-label="Actividad ordenar sílabas">
       <header class="activity-topbar">
-        <button id="home-btn" class="back-btn" type="button" aria-label="Volver a la portada">Salir</button>
+        <button id="home-btn" class="back-btn" type="button" aria-label="Volver a la portada">Volver</button>
 
-        <div class="top-meta">
-          <p class="eyebrow" id="level-label">Nivel 1</p>
-          <h2 id="round-word">2 sílabas</h2>
+        <div class="hud-item">
+          <span class="hud-label">Nivel</span>
+          <strong id="level-label">Nivel 1</strong>
         </div>
 
-        <div class="top-controls">
-          <div class="mode-tabs" aria-label="Selector de modo">
-            <button class="mode-btn is-active" data-mode="normal">Normal</button>
-            <button class="mode-btn" data-mode="intruders" disabled title="Próximamente">Intrusos</button>
-          </div>
-          <div class="score-box" aria-label="Aciertos acumulados">
-            <span>Aciertos</span>
-            <strong id="score">0</strong>
-          </div>
+        <div class="hud-item hud-item--progress">
+          <span class="hud-label">Progreso</span>
+          <strong id="progress-text">0/2</strong>
+        </div>
+
+        <div class="hud-item hud-item--score" aria-label="Aciertos acumulados">
+          <span class="hud-label">Aciertos</span>
+          <strong id="score">0</strong>
         </div>
       </header>
 
@@ -56,16 +55,20 @@
 
       <footer class="activity-footer">
         <div class="level-tabs" aria-label="Selector de nivel">
-          <button class="level-btn is-active" data-level="1">Nivel 1</button>
-          <button class="level-btn" data-level="2">Nivel 2</button>
-          <button class="level-btn" data-level="3">Nivel 3</button>
+          <button class="level-btn is-active" data-level="1">N1</button>
+          <button class="level-btn" data-level="2">N2</button>
+          <button class="level-btn" data-level="3">N3</button>
+        </div>
+
+        <div class="footer-center">
+          <p class="build-label">Construcción actual</p>
+          <div id="build-word" class="build-word" aria-live="polite">—</div>
+          <p id="feedback" class="feedback" aria-live="polite"></p>
         </div>
 
         <div class="footer-actions">
-          <button id="next-btn" class="secondary-btn">Nueva palabra</button>
+          <button id="next-btn" class="secondary-btn">Nueva</button>
         </div>
-
-        <p id="feedback" class="feedback" aria-live="polite"></p>
       </footer>
     </section>
   </div>

--- a/main.js
+++ b/main.js
@@ -4,7 +4,6 @@ import { createHomeController } from './src/ui/home.js';
 import { createRouter } from './src/navigation/router.js';
 import { createExerciseRegistry } from './src/core/exerciseRegistry.js';
 import { createOrderSyllablesPlugin } from './src/exercises/orderSyllablesPlugin.js';
-import { ORDER_MODES } from './src/exercises/orderSyllablesConfig.js';
 
 const refs = {
   appRoot: document.querySelector('#app-root'),
@@ -12,13 +11,13 @@ const refs = {
   exerciseScreen: document.querySelector('#exercise-screen'),
   homeBtn: document.querySelector('#home-btn'),
   levelButtons: document.querySelectorAll('.level-btn'),
-  modeButtons: document.querySelectorAll('.mode-btn'),
   exerciseContainer: document.querySelector('#exercise-container'),
   feedback: document.querySelector('#feedback'),
   score: document.querySelector('#score'),
-  roundWord: document.querySelector('#round-word'),
   levelLabel: document.querySelector('#level-label'),
-  nextBtn: document.querySelector('#next-btn')
+  nextBtn: document.querySelector('#next-btn'),
+  progressText: document.querySelector('#progress-text'),
+  buildWord: document.querySelector('#build-word')
 };
 
 const POSITION_PATTERNS = {
@@ -47,6 +46,8 @@ function updateAnswerSlots(answer = []) {
   slots.forEach((slot, index) => {
     slot.textContent = answer[index]?.toUpperCase() ?? '';
   });
+  refs.progressText.textContent = `${answer.length}/${slots.length || 0}`;
+  refs.buildWord.textContent = answer.length ? answer.map((part) => part.toUpperCase()).join('') : '—';
 }
 
 function renderRound(viewModel) {
@@ -57,7 +58,6 @@ function renderRound(viewModel) {
   }
 
   refs.levelLabel.textContent = viewModel.levelLabel;
-  refs.roundWord.textContent = `${viewModel.expectedLength} sílabas · ${viewModel.modeLabel}`;
 
   const piecesWrap = document.createElement('div');
   piecesWrap.className = 'pieces-cloud';
@@ -82,7 +82,6 @@ function renderRound(viewModel) {
 
   const answerWrap = document.createElement('div');
   answerWrap.className = 'answer-zone';
-  answerWrap.innerHTML = '<p class="answer-zone__label">Construye la palabra</p>';
 
   const slotsWrap = document.createElement('div');
   slotsWrap.className = 'answer-slots';
@@ -153,21 +152,6 @@ function setLevel(level) {
   setFeedback('Toca las sílabas en orden para formar una palabra.', '');
 }
 
-function setMode(mode) {
-  const modeConfig = ORDER_MODES[mode] ?? ORDER_MODES.normal;
-  if (!modeConfig.enabled) {
-    setFeedback('Este modo estará disponible próximamente.', 'error');
-    return;
-  }
-
-  state.currentMode = modeConfig.id;
-  refs.modeButtons.forEach((btn) => btn.classList.toggle('is-active', btn.dataset.mode === modeConfig.id));
-  const plugin = getActivePlugin();
-  if (!plugin) return;
-  renderRound(plugin.start({ level: state.currentLevel, mode: state.currentMode }));
-  setFeedback('Toca las sílabas en orden para formar una palabra.', '');
-}
-
 function openExercise(exerciseId) {
   const plugin = registry.get(exerciseId);
   if (!plugin) {
@@ -190,10 +174,6 @@ function init() {
 
   refs.levelButtons.forEach((button) => {
     button.addEventListener('click', () => setLevel(Number(button.dataset.level)));
-  });
-
-  refs.modeButtons.forEach((button) => {
-    button.addEventListener('click', () => setMode(button.dataset.mode));
   });
 
   refs.nextBtn.addEventListener('click', startRound);

--- a/style.css
+++ b/style.css
@@ -1,356 +1,167 @@
 :root {
-  --bg: #f4f1eb;
-  --bg-2: #ece5db;
-  --surface: rgba(255, 255, 255, 0.92);
-  --surface-strong: #ffffff;
-  --surface-soft: #f7f3ed;
-  --text: #231d19;
-  --muted: #6f655d;
-  --accent: #6f4f3b;
-  --accent-2: #87624a;
-  --success: #2f7d46;
-  --error: #bf4747;
-  --line: rgba(74, 52, 35, 0.16);
-  --line-soft: rgba(74, 52, 35, 0.1);
-  --shadow-xs: 0 2px 8px rgba(28, 16, 8, 0.05);
-  --shadow-sm: 0 8px 22px rgba(28, 16, 8, 0.08);
-  --shadow-md: 0 16px 38px rgba(28, 16, 8, 0.12);
-  --radius-xl: 28px;
-  --radius-lg: 20px;
-  --radius-md: 16px;
-  --transition: 220ms cubic-bezier(.22, .61, .36, 1);
+  --bg-a: #f5f7fb;
+  --bg-b: #edf2fb;
+  --text: #1b2430;
+  --muted: #6e7888;
+  --accent: #4c6fff;
+  --accent-soft: #dbe4ff;
+  --success: #1f9b57;
+  --error: #d04c4c;
+  --line: rgba(62, 76, 103, 0.2);
+  --radius-lg: 18px;
+  --radius-md: 14px;
 }
-
 * { box-sizing: border-box; }
-
 body {
   margin: 0;
-  font-family: "Nunito", "Avenir Next", "Segoe UI", "Inter", system-ui, -apple-system, sans-serif;
-  background:
-    radial-gradient(1100px 400px at 10% -10%, rgba(255, 255, 255, 0.72), transparent 60%),
-    radial-gradient(900px 340px at 90% -10%, rgba(255, 255, 255, 0.62), transparent 58%),
-    linear-gradient(180deg, var(--bg), var(--bg-2));
+  font-family: "Nunito", "Inter", system-ui, sans-serif;
+  background: linear-gradient(160deg, var(--bg-a), var(--bg-b));
   color: var(--text);
   min-height: 100dvh;
 }
-
-body.is-activity-mode {
-  overflow: hidden;
-}
-
-.app {
-  width: min(100% - 30px, 940px);
-  margin: 28px auto;
-  position: relative;
-  min-height: calc(100dvh - 56px);
-}
-
+body.is-activity-mode { overflow: hidden; }
+.app { width: 100%; min-height: 100dvh; position: relative; }
 .view {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  gap: 20px;
-  align-content: start;
-  opacity: 0;
-  transform: translateY(12px) scale(0.996);
-  pointer-events: none;
-  visibility: hidden;
-  transition: opacity var(--transition), transform var(--transition), visibility 0s linear 220ms;
+  position: absolute; inset: 0; opacity: 0; transform: translateY(8px);
+  pointer-events: none; visibility: hidden;
+  transition: opacity 220ms ease, transform 220ms ease;
 }
-
-.view.is-active-view {
-  opacity: 1;
-  transform: translateY(0) scale(1);
-  pointer-events: auto;
-  visibility: visible;
-  transition: opacity var(--transition), transform var(--transition);
-}
+.view.is-active-view { opacity: 1; transform: translateY(0); pointer-events: auto; visibility: visible; }
 
 .panel {
-  background: var(--surface);
-  border: 1px solid var(--line-soft);
-  border-radius: var(--radius-xl);
-  padding: clamp(18px, 3vw, 28px);
-  box-shadow: var(--shadow-sm);
-  backdrop-filter: blur(6px);
+  width: min(100% - 30px, 900px);
+  margin: 18px auto;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  padding: 24px;
 }
-
-.eyebrow { margin: 0 0 8px; font-size: .78rem; text-transform: uppercase; letter-spacing: .11em; color: var(--muted); font-weight: 800; }
-h1, h2 { margin: 0; line-height: 1.14; letter-spacing: -.01em; }
-h1 { font-size: clamp(1.45rem, 2.6vw, 2rem); }
-h2 { font-size: clamp(1.05rem, 2vw, 1.32rem); }
-.subtitle { margin: 10px 0 0; color: var(--muted); max-width: 72ch; line-height: 1.5; }
-
-.home-screen {
-  gap: 22px;
-  background:
-    radial-gradient(130% 100% at 8% 8%, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0) 50%),
-    linear-gradient(170deg, #f8f4ed 8%, #f1e8dc 50%, #ecdfd1 100%);
-  border: 1px solid rgba(111, 79, 59, 0.18);
-  box-shadow: 0 18px 44px rgba(22, 14, 7, 0.14);
-}
-
-.exercise-menu { display: grid; gap: 12px; }
-.exercise-card {
-  width: 100%;
-  border: 1px solid rgba(111, 79, 59, 0.17);
-  border-radius: 20px;
-  background: radial-gradient(120% 120% at 20% 15%, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.32));
-  padding: 16px 18px;
-  text-align: left;
-  display: grid;
-  gap: 5px;
-  box-shadow: inset 0 -2px 0 rgba(111, 79, 59, 0.1), var(--shadow-xs);
-  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition);
-}
-.exercise-card strong { font-size: 1rem; }
-.exercise-card span { color: var(--muted); font-size: .92rem; }
-.exercise-card:not(.is-disabled):hover { transform: translateY(-2px); box-shadow: var(--shadow-sm); border-color: rgba(111, 79, 59, 0.24); }
-.exercise-card:not(.is-disabled):active { transform: translateY(0) scale(0.99); }
-.exercise-card.is-disabled { opacity: .56; cursor: not-allowed; }
+.eyebrow { margin: 0 0 8px; font-size: .78rem; letter-spacing: .11em; color: var(--muted); text-transform: uppercase; font-weight: 800; }
+h1 { margin: 0; }
+.subtitle { color: var(--muted); }
+.exercise-menu { display: grid; gap: 10px; }
+.exercise-card { padding: 15px; border-radius: 16px; border: 1px solid var(--line); background: #fff; text-align: left; }
+.exercise-card.is-disabled { opacity: .55; }
 
 .exercise-screen {
-  inset: -12px;
-  padding: clamp(12px, 2.8vw, 28px);
-  border-radius: 30px;
-  gap: clamp(10px, 1.8vh, 16px);
+  display: grid;
+  grid-template-rows: 56px 1fr 128px;
+  min-height: 100dvh;
+  padding: clamp(10px, 1.5vw, 16px);
+  gap: 10px;
   background:
-    radial-gradient(88% 90% at 8% 10%, rgba(255, 255, 255, 0.5), transparent 62%),
-    radial-gradient(90% 85% at 92% 16%, rgba(255, 236, 214, 0.34), transparent 66%),
-    linear-gradient(165deg, #f0e6d7 0%, #e9dccb 36%, #e4d6c2 72%, #dfcfbb 100%);
-  border: 1px solid rgba(89, 62, 44, 0.22);
-  box-shadow:
-    0 24px 54px rgba(22, 14, 7, 0.2),
-    inset 0 1px 0 rgba(255, 255, 255, 0.45);
-  min-height: 100%;
-  grid-template-rows: auto 1fr auto;
-  overflow: hidden;
-}
-
-.exercise-screen::before,
-.exercise-screen::after {
-  content: "";
-  position: absolute;
-  pointer-events: none;
-}
-
-.exercise-screen::before {
-  inset: 14px;
-  border-radius: 24px;
-  background-image:
-    linear-gradient(115deg, rgba(255, 255, 255, 0.08) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.08) 50%, rgba(255, 255, 255, 0.08) 75%, transparent 75%, transparent);
-  background-size: 16px 16px;
-  opacity: .22;
-}
-
-.exercise-screen::after {
-  width: 46%;
-  height: 40%;
-  right: -8%;
-  bottom: -12%;
-  border-radius: 999px;
-  background: radial-gradient(circle at center, rgba(255, 223, 173, 0.3), transparent 70%);
-  filter: blur(10px);
-}
-
-.activity-topbar,
-.activity-footer {
-  background: rgba(255, 255, 255, 0.68);
-  border: 1px solid rgba(111, 79, 59, 0.14);
-  border-radius: 20px;
-  backdrop-filter: blur(7px);
+    radial-gradient(800px 260px at 50% -120px, rgba(110, 149, 255, 0.14), transparent 65%),
+    linear-gradient(170deg, #f7faff 0%, #edf3ff 46%, #e8f0ff 100%);
 }
 
 .activity-topbar {
-  min-height: clamp(72px, 10vh, 92px);
   display: grid;
-  grid-template-columns: auto minmax(150px, 1fr) auto;
-  align-items: center;
-  gap: 14px;
-  padding: 10px clamp(12px, 2.5vw, 18px);
-}
-
-.top-meta .eyebrow { margin-bottom: 2px; }
-.top-meta h2 { margin: 0; }
-.top-controls { display: flex; align-items: center; gap: 10px; }
-
-.back-btn,
-.level-btn,
-.mode-btn,
-.secondary-btn {
-  border: 1px solid var(--line-soft);
-  background: #fff;
-  border-radius: 999px;
-  min-height: 42px;
-  padding: 0 16px;
-  font-weight: 800;
-  color: var(--text);
-  transition: transform 160ms ease, box-shadow var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
-}
-
-.score-box {
-  background: linear-gradient(180deg, #f8f4ee, #f2ebe2);
-  border: 1px solid var(--line-soft);
-  border-radius: 999px;
-  padding: 8px 13px;
-  display: flex;
+  grid-template-columns: auto auto 1fr auto;
   align-items: center;
   gap: 8px;
-  white-space: nowrap;
+  border: 1px solid rgba(76, 111, 255, 0.16);
+  border-radius: 999px;
+  padding: 6px 8px;
+  background: rgba(255, 255, 255, 0.88);
 }
-
-.level-tabs,
-.mode-tabs { display: flex; gap: 8px; flex-wrap: wrap; }
-.level-btn.is-active,
-.mode-btn.is-active { background: linear-gradient(180deg, var(--accent-2), var(--accent)); border-color: transparent; color: #fff; box-shadow: 0 8px 16px rgba(95, 68, 53, 0.28); }
-.mode-btn[disabled] { opacity: .5; cursor: not-allowed; }
+.back-btn, .level-btn, .secondary-btn {
+  border: 1px solid var(--line);
+  background: #fff;
+  border-radius: 999px;
+  min-height: 38px;
+  padding: 0 14px;
+  font-weight: 800;
+  color: var(--text);
+}
+.hud-item { display: flex; align-items: baseline; gap: 7px; padding: 0 8px; }
+.hud-item--score { justify-self: end; }
+.hud-label { font-size: .72rem; letter-spacing: .09em; text-transform: uppercase; color: var(--muted); font-weight: 800; }
+#level-label, #progress-text, #score { font-size: 1rem; }
 
 .activity-stage {
   min-height: 0;
-  overflow: hidden;
-  background: rgba(255, 255, 255, 0.2);
-  border-radius: 24px;
-  border: 1px solid rgba(102, 72, 54, 0.15);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
-  padding: clamp(10px, 1.6vw, 16px);
+  border-radius: 26px;
+  padding: clamp(14px, 2vw, 22px);
+  background: rgba(255, 255, 255, 0.44);
+  border: 1px solid rgba(76, 111, 255, 0.12);
 }
-
-.exercise-container,
-.pieces-cloud {
-  height: 100%;
-}
-
-.exercise-container {
-  display: grid;
-  grid-template-rows: 1fr auto;
-  gap: clamp(10px, 2vh, 18px);
-}
-
-.pieces-cloud {
-  position: relative;
-  min-height: 0;
-  border-radius: 30px;
-  background:
-    radial-gradient(120% 100% at 18% 12%, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.28)),
-    linear-gradient(180deg, rgba(255, 252, 246, 0.95), rgba(249, 240, 228, 0.95));
-  border: 1px solid rgba(111, 79, 59, 0.22);
-  box-shadow:
-    inset 0 -2px 0 rgba(111, 79, 59, 0.1),
-    0 14px 30px rgba(28, 17, 9, 0.12);
-}
-
-.pieces-cloud::before {
-  content: "";
-  position: absolute;
-  inset: 10px;
-  border-radius: 22px;
-  border: 1px dashed rgba(111, 79, 59, 0.2);
-  opacity: .38;
-  pointer-events: none;
-}
+.exercise-container { height: 100%; display: grid; grid-template-rows: 1fr auto; gap: 18px; }
+.pieces-cloud { position: relative; min-height: 0; height: 100%; }
 
 .syllable-piece {
   position: absolute;
-  min-width: clamp(124px, 18vw, 196px);
-  min-height: clamp(82px, 10vh, 108px);
-  padding: clamp(14px, 2.1vh, 20px) clamp(24px, 3vw, 34px);
-  border-radius: 30px;
-  border: 1px solid rgba(111, 79, 59, 0.24);
-  background:
-    linear-gradient(178deg, #fffcf8 0%, #fff4e4 58%, #fbe9d1 100%);
-  box-shadow:
-    0 14px 22px rgba(32, 20, 12, 0.16),
-    0 5px 0 rgba(138, 99, 74, 0.24),
-    inset 0 1px 0 rgba(255, 255, 255, 0.8);
-  font-size: clamp(1.42rem, 4vw, 2.3rem);
+  min-width: clamp(160px, 18vw, 260px);
+  min-height: clamp(96px, 12vh, 132px);
+  padding: 18px 30px;
+  border: 0;
+  border-radius: 28px;
+  background: linear-gradient(170deg, #ffffff 0%, #eef3ff 100%);
+  box-shadow: 0 18px 28px rgba(60, 89, 172, 0.18), 0 4px 0 rgba(110, 137, 217, 0.26);
+  font-size: clamp(2rem, 4.7vw, 3rem);
   font-weight: 900;
-  letter-spacing: .03em;
-  color: #2c2119;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
-  transform-origin: center;
-  transition: transform 180ms cubic-bezier(.2, .8, .28, 1.35), box-shadow var(--transition), border-color var(--transition), background var(--transition), color var(--transition), filter var(--transition);
+  letter-spacing: .02em;
+  color: #24345f;
+  transition: transform 220ms cubic-bezier(.2,.9,.28,1.2), box-shadow 220ms ease, filter 220ms ease;
 }
+.syllable-piece:hover { transform: translateY(-4px) scale(1.02); box-shadow: 0 22px 34px rgba(60, 89, 172, 0.21), 0 6px 0 rgba(110, 137, 217, 0.24), 0 0 0 7px rgba(132, 157, 255, 0.15); }
+.syllable-piece:active { transform: scale(0.95); box-shadow: 0 10px 16px rgba(60, 89, 172, 0.2), 0 2px 0 rgba(110, 137, 217, 0.28), 0 0 0 10px rgba(132, 157, 255, 0.2); }
 
-.syllable-piece:hover {
-  transform: translateY(-4px) scale(1.024);
-  box-shadow:
-    0 18px 26px rgba(32, 20, 12, 0.18),
-    0 6px 0 rgba(138, 99, 74, 0.2),
-    0 0 0 5px rgba(255, 213, 157, 0.2);
-}
-.syllable-piece:active {
-  transform: translateY(1px) scale(0.965);
-  box-shadow:
-    0 8px 14px rgba(32, 20, 12, 0.16),
-    0 2px 0 rgba(138, 99, 74, 0.22),
-    0 0 0 6px rgba(255, 213, 157, 0.26);
-}
-
-.slot-a { top: 9%; left: 8%; }
-.slot-b { top: 12%; left: 34%; }
-.slot-c { top: 37%; left: 18%; }
-.slot-d { top: 58%; left: 55%; }
-.slot-e { top: 24%; left: 61%; }
-.slot-f { top: 63%; left: 8%; }
+.slot-a { top: 9%; left: 7%; }
+.slot-b { top: 8%; left: 38%; }
+.slot-c { top: 39%; left: 18%; }
+.slot-d { top: 54%; left: 58%; }
+.slot-e { top: 22%; left: 63%; }
+.slot-f { top: 62%; left: 10%; }
 
 .answer-zone {
-  background:
-    radial-gradient(120% 100% at 12% 8%, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.66)),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(249, 239, 225, 0.9));
-  border: 1px solid rgba(111, 79, 59, 0.24);
-  border-radius: 24px;
-  padding: clamp(14px, 2.2vw, 20px);
-  box-shadow: 0 12px 22px rgba(29, 19, 11, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  justify-self: center;
+  width: min(100%, 920px);
+  background: transparent;
+  border: 0;
+  padding: 0;
 }
-.answer-zone__label { margin: 0 0 12px; font-weight: 900; color: #5e4b3f; letter-spacing: .015em; }
-.answer-slots { display: flex; gap: 12px; flex-wrap: wrap; }
+.answer-slots { display: flex; justify-content: center; gap: 16px; flex-wrap: wrap; }
 .answer-slot {
-  min-width: clamp(76px, 13vw, 116px);
-  min-height: clamp(66px, 8.5vh, 86px);
+  min-width: clamp(100px, 10vw, 130px);
+  min-height: clamp(76px, 8.5vh, 88px);
   display: grid;
   place-items: center;
-  background: linear-gradient(180deg, #fffdf9, #fdf2e2);
-  border: 1px solid rgba(111, 79, 59, 0.22);
+  background: #f8fbff;
+  border: 2px dashed rgba(95, 117, 181, 0.34);
   border-radius: 16px;
-  font-size: clamp(1.3rem, 3vw, 1.9rem);
+  font-size: clamp(1.6rem, 3vw, 2.15rem);
   font-weight: 900;
-  color: #2f261f;
-  box-shadow: inset 0 -3px 0 rgba(111, 79, 59, 0.12), 0 8px 14px rgba(25, 16, 10, 0.09);
-  transition: transform var(--transition), box-shadow var(--transition);
+  color: #2a3f75;
 }
 
 .activity-footer {
-  padding: 10px clamp(12px, 2.5vw, 18px);
   display: grid;
-  gap: 8px;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 2px;
 }
-.footer-actions { justify-self: end; }
-.feedback { min-height: 24px; margin: 0; padding: 8px 10px; border-radius: 10px; font-weight: 800; color: var(--muted); }
-.feedback.is-success { color: var(--success); background: rgba(47, 125, 70, 0.1); box-shadow: 0 0 0 1px rgba(47, 125, 70, 0.2) inset; }
-.feedback.is-error { color: var(--error); background: rgba(191, 71, 71, 0.09); box-shadow: 0 0 0 1px rgba(191, 71, 71, 0.2) inset; }
+.level-tabs { display: flex; gap: 8px; }
+.level-btn.is-active { background: var(--accent); color: #fff; border-color: transparent; }
+.footer-center { text-align: center; }
+.build-label { margin: 0 0 2px; color: var(--muted); font-size: .86rem; }
+.build-word { font-size: clamp(2rem, 5vw, 3.2rem); font-weight: 900; letter-spacing: .07em; min-height: 1.2em; }
+.feedback { margin: 3px 0 0; min-height: 20px; color: var(--muted); font-weight: 700; }
+.feedback.is-success { color: var(--success); }
+.feedback.is-error { color: var(--error); }
 
-.syllable-piece.is-correct { animation: pulse 340ms cubic-bezier(.24, .65, .31, 1.2); border-color: rgba(47, 125, 70, 0.42); box-shadow: 0 0 0 7px rgba(47, 125, 70, 0.1), 0 14px 22px rgba(32, 20, 12, 0.14); }
-.syllable-piece.is-wrong { animation: shake 320ms cubic-bezier(.36, .07, .19, .97); border-color: rgba(191, 71, 71, 0.58); background: linear-gradient(180deg, #fff, #fff5f5); color: var(--error); }
-
-@keyframes shake { 20% { transform: translateX(-3px); } 40% { transform: translateX(4px); } 60% { transform: translateX(-2px); } 80% { transform: translateX(2px); } 100% { transform: translateX(0); } }
-@keyframes pulse { 45% { transform: scale(1.05); } 100% { transform: scale(1); } }
-
+.syllable-piece.is-correct { animation: pulse 320ms cubic-bezier(.24, .65, .31, 1.2); }
+.syllable-piece.is-wrong { animation: shake 280ms cubic-bezier(.36,.07,.19,.97); filter: saturate(.75); }
+@keyframes shake { 20% { transform: translateX(-4px); } 40% { transform: translateX(4px); } 60% { transform: translateX(-2px); } 80% { transform: translateX(2px); } 100% { transform: translateX(0); } }
+@keyframes pulse { 50% { transform: scale(1.07); } 100% { transform: scale(1); } }
 button:focus-visible { outline: 3px solid #2f75f3; outline-offset: 2px; }
-.exercise-card, .level-btn, .mode-btn, .secondary-btn, .back-btn, .syllable-piece { cursor: pointer; }
+.exercise-card, .level-btn, .secondary-btn, .back-btn, .syllable-piece { cursor: pointer; }
 
-@media (max-width: 860px) {
-  .app { width: 100%; margin: 0; min-height: 100dvh; }
-  .home-screen.panel { margin: 12px; min-height: calc(100dvh - 24px); }
-  .exercise-screen { inset: 0; border-radius: 0; border: 0; }
-}
-
-@media (max-width: 640px) {
-  .activity-topbar { grid-template-columns: auto 1fr; grid-template-areas: "exit meta" "controls controls"; align-items: start; }
-  .back-btn { grid-area: exit; }
-  .top-meta { grid-area: meta; text-align: right; }
-  .top-controls { grid-area: controls; justify-content: space-between; width: 100%; }
-  .mode-tabs { max-width: 68%; }
-  .level-tabs { justify-content: center; }
-  .footer-actions { justify-self: stretch; }
-  .secondary-btn { width: 100%; }
+@media (max-width: 800px) {
+  .exercise-screen { grid-template-rows: auto 1fr auto; }
+  .activity-topbar { grid-template-columns: auto 1fr auto; }
+  .hud-item--progress { justify-self: end; }
+  .hud-item--score { grid-column: 3; }
+  .activity-footer { grid-template-columns: 1fr; }
+  .level-tabs, .footer-actions { justify-content: center; }
 }


### PR DESCRIPTION
### Motivation
- El objetivo es eliminar la estética tipo dashboard/cards y convertir la pantalla de ejercicio en una única escena fullscreen con foco absoluto en las sílabas. 
- Buscar una experiencia táctil y moderna: HUD superior mínimo, tablero central dominante y una franja inferior compacta para la construcción de la palabra.

### Description
- Reestructuré el HTML en `index.html` para un HUD minimal (`#level-label`, `#progress-text`, `#score`), un `#exercise-container` central y una franja inferior con `#build-word`, `#feedback` y el botón `#next-btn`.
- Actualicé la lógica en `main.js`: eliminé `ORDER_MODES`/`setMode` y el manejo de botones de modo, añadí referencias a `progressText` y `buildWord`, y cambié `updateAnswerSlots` para actualizar `progressText` y la palabra construida en tiempo real.
- Reescribí `style.css` para un layout fullscreen y visual táctil: nuevo sistema de variables, fondo con degradado sutil, topbar discreto, piezas `.syllable-piece` mucho más grandes con sombras/animaciones táctiles, espacio vacío ampliado y simplificación de contenedores (menos panels/cards/blur).
- Cambios de UI menores: renombré los botones de nivel a `N1/N2/N3`, ajusté posiciones de slots (`.slot-*`) y simplifiqué la `answer-zone` para dar protagonismo visual a las sílabas.

### Testing
- Ejecuté la comprobación de sintaxis de JS con `node --check main.js`, y pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1d989818832d81af8973d321cd31)