### PR TITLE
Añade sesión cerrada de 15 palabras y barra de progreso en Ordenar sílabas

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,12 @@
             <span>Aciertos</span>
             <strong id="score">0</strong>
           </div>
+          <div class="progress-box" aria-label="Progreso del ejercicio de sílabas">
+            <span id="progress-label">0/15</span>
+            <div class="progress-track" role="progressbar" aria-valuemin="0" aria-valuemax="15" aria-valuenow="0" aria-labelledby="progress-label">
+              <div id="progress-fill" class="progress-fill"></div>
+            </div>
+          </div>
         </div>
       </header>
 

--- a/main.js
+++ b/main.js
@@ -16,6 +16,9 @@ const refs = {
   exerciseContainer: document.querySelector('#exercise-container'),
   feedback: document.querySelector('#feedback'),
   score: document.querySelector('#score'),
+  progressLabel: document.querySelector('#progress-label'),
+  progressFill: document.querySelector('#progress-fill'),
+  progressTrack: document.querySelector('.progress-track'),
   roundWord: document.querySelector('#round-word'),
   levelLabel: document.querySelector('#level-label'),
   nextBtn: document.querySelector('#next-btn')
@@ -27,7 +30,15 @@ const POSITION_PATTERNS = {
   4: ['slot-a', 'slot-b', 'slot-d', 'slot-f']
 };
 
-const state = { activeExerciseId: null, currentLevel: 1, currentMode: 'normal' };
+const SESSION_WORDS_TARGET = 15;
+
+const state = {
+  activeExerciseId: null,
+  currentLevel: 1,
+  currentMode: 'normal',
+  completedWords: 0,
+  isSessionFinished: false
+};
 const registry = createExerciseRegistry();
 registry.register(createOrderSyllablesPlugin());
 
@@ -40,6 +51,22 @@ function setFeedback(message, type = '') {
 
 function getLayoutClass(pieceCount) {
   return POSITION_PATTERNS[pieceCount] ?? POSITION_PATTERNS[3];
+}
+
+
+function updateProgress() {
+  const progress = Math.min(state.completedWords, SESSION_WORDS_TARGET);
+  const percent = (progress / SESSION_WORDS_TARGET) * 100;
+  refs.progressLabel.textContent = `${progress}/${SESSION_WORDS_TARGET}`;
+  refs.progressFill.style.width = `${percent}%`;
+  refs.progressTrack?.setAttribute('aria-valuenow', String(progress));
+}
+
+function resetSessionProgress() {
+  state.completedWords = 0;
+  state.isSessionFinished = false;
+  refs.score.textContent = '0';
+  updateProgress();
 }
 
 function updateAnswerSlots(answer = []) {
@@ -133,6 +160,15 @@ function handleSyllableTap(button) {
 
   if (result.status === 'correct') {
     refs.score.textContent = String(result.score);
+    state.completedWords += 1;
+    updateProgress();
+
+    if (state.completedWords >= SESSION_WORDS_TARGET) {
+      state.isSessionFinished = true;
+      setFeedback('¡Muy bien! Terminaste el ejercicio de 15 palabras.', 'success');
+      return;
+    }
+
     setFeedback('Excelente. Nueva palabra…', 'success');
     window.setTimeout(startRound, 900);
   }
@@ -141,15 +177,31 @@ function handleSyllableTap(button) {
 function startRound() {
   const plugin = getActivePlugin();
   if (!plugin) return;
+
+  if (state.isSessionFinished) {
+    setFeedback('Sesión completada (15/15). Cambia de nivel o vuelve al inicio para comenzar otra.', 'success');
+    return;
+  }
+
   renderRound(plugin.start({ level: state.currentLevel, mode: state.currentMode }));
   setFeedback('Toca las sílabas en orden para formar una palabra.', '');
 }
 
 function setLevel(level) {
+  if (state.currentLevel === level) return;
+
+  const hasSessionProgress = state.completedWords > 0 && !state.isSessionFinished;
+  if (hasSessionProgress) {
+    const shouldChange = window.confirm('Hay un ejercicio en curso. ¿Quieres interrumpirlo para cambiar de nivel?');
+    if (!shouldChange) return;
+  }
+
   state.currentLevel = level;
   refs.levelButtons.forEach((btn) => btn.classList.toggle('is-active', Number(btn.dataset.level) === level));
+  resetSessionProgress();
+
   const plugin = getActivePlugin();
-  renderRound(plugin.start({ level, mode: state.currentMode }));
+  renderRound(plugin.start({ level, mode: state.currentMode, resetScore: true }));
   setFeedback('Toca las sílabas en orden para formar una palabra.', '');
 }
 
@@ -177,9 +229,11 @@ function openExercise(exerciseId) {
   state.activeExerciseId = exerciseId;
   router.navigateExercise();
   document.body.classList.add('is-activity-mode');
-  refs.score.textContent = '0';
-  plugin.start({ level: 1, mode: 'normal', resetScore: true });
-  setLevel(1);
+  state.currentLevel = 1;
+  refs.levelButtons.forEach((btn) => btn.classList.toggle('is-active', Number(btn.dataset.level) === 1));
+  resetSessionProgress();
+  renderRound(plugin.start({ level: 1, mode: 'normal', resetScore: true }));
+  setFeedback('Toca las sílabas en orden para formar una palabra.', '');
 }
 
 function init() {
@@ -210,6 +264,7 @@ function init() {
     setFeedback('');
   });
 
+  updateProgress();
   router.init('home');
   document.body.classList.remove('is-activity-mode');
 }

--- a/style.css
+++ b/style.css
@@ -199,6 +199,35 @@ h2 { font-size: clamp(1.05rem, 2vw, 1.32rem); }
   white-space: nowrap;
 }
 
+
+.progress-box {
+  min-width: 150px;
+  display: grid;
+  gap: 6px;
+}
+
+.progress-box span {
+  font-weight: 800;
+  color: var(--muted);
+  font-size: .9rem;
+  text-align: right;
+}
+
+.progress-track {
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(111, 79, 59, 0.16);
+  overflow: hidden;
+  box-shadow: inset 0 1px 2px rgba(35, 29, 25, 0.14);
+}
+
+.progress-fill {
+  width: 0%;
+  height: 100%;
+  background: linear-gradient(90deg, #73b782, #2f7d46);
+  transition: width 180ms ease;
+}
+
 .level-tabs,
 .mode-tabs { display: flex; gap: 8px; flex-wrap: wrap; }
 .level-btn.is-active,
@@ -348,7 +377,9 @@ button:focus-visible { outline: 3px solid #2f75f3; outline-offset: 2px; }
   .activity-topbar { grid-template-columns: auto 1fr; grid-template-areas: "exit meta" "controls controls"; align-items: start; }
   .back-btn { grid-area: exit; }
   .top-meta { grid-area: meta; text-align: right; }
-  .top-controls { grid-area: controls; justify-content: space-between; width: 100%; }
+  .top-controls { grid-area: controls; justify-content: space-between; width: 100%; flex-wrap: wrap; }
+  .progress-box { width: 100%; }
+  .progress-box span { text-align: left; }
   .mode-tabs { max-width: 68%; }
   .level-tabs { justify-content: center; }
   .footer-actions { justify-self: stretch; }


### PR DESCRIPTION
### Motivation
- Limitar el ejercicio de "Ordenar sílabas" a sesiones cerradas de 15 palabras para ajustar duración y métricas de práctica. 
- Mostrar un marcador visual claro (contador y barra) para que el usuario vea el progreso de la sesión. 
- Evitar pérdida accidental de progreso al cambiar de nivel mostrando una confirmación antes de interrumpir la sesión. 

### Description
- Añade una UI de progreso en la cabecera del ejercicio con `#progress-label`, `.progress-track` y `#progress-fill` en `index.html` y estilos en `style.css` para la barra y comportamiento responsive. 
- Introduce `SESSION_WORDS_TARGET`, `state.completedWords` y `state.isSessionFinished` en `main.js` y añade las funciones `updateProgress()` y `resetSessionProgress()` para gestionar y renderizar el avance. 
- Incrementa `completedWords` al validar respuestas correctas, detiene la generación automática de nuevas rondas cuando se alcanza 15/15 y muestra un mensaje de finalización. 
- Solicita confirmación con `window.confirm` en `setLevel` si hay progreso en curso y, si se confirma, reinicia el progreso y la puntuación al cambiar de nivel; también reinicia el progreso al abrir el ejercicio. 
- Archivos modificados: `main.js`, `index.html`, `style.css`. 

### Testing
- Verificada la diferencia de cambios y el contenido modificado inspeccionando las tres fuentes con revisión de diffs y listados (`git diff` y revisión de los archivos modificados), y se confirmó la presencia de las nuevas funciones y elementos. 
- Inspeccionados los archivos actualizados con `nl -ba main.js`, `nl -ba index.html` y `nl -ba style.css` para validar inserciones y posiciones de código. 
- Ejecutadas las sustituciones programáticas que añadieron la UI y las funciones (scripts de edición aplicados) y comprobado que los selectores `#progress-label`, `#progress-fill` y `.progress-track` existen en `main.js` tras los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b20f54910832d812ffeb1cfa8b457)