### PR TITLE
Reordena sílabas en cada cambio de palabra

### DIFF
--- a/src/exercises/orderSyllables.js
+++ b/src/exercises/orderSyllables.js
@@ -9,8 +9,31 @@ function getLinguisticCandidates(levelConfig) {
   return base.filter((word) => word.structure !== 'CV-CV-CV');
 }
 
+function hasSameOrder(left, right) {
+  if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((item, index) => item === right[index]);
+}
+
+function ensureReorderedSyllables(syllables) {
+  if (!Array.isArray(syllables) || syllables.length <= 1) {
+    return [...syllables];
+  }
+
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const candidate = shuffleArray(syllables);
+    if (!hasSameOrder(candidate, syllables)) {
+      return candidate;
+    }
+  }
+
+  return [...syllables.slice(1), syllables[0]];
+}
+
 function createSyllablePieces(syllables) {
-  const shuffled = shuffleArray(syllables);
+  const shuffled = ensureReorderedSyllables(syllables);
 
   return shuffled.map((text, index) => ({
     id: `${text}-${index}`,

--- a/src/exercises/orderSyllablesPlugin.js
+++ b/src/exercises/orderSyllablesPlugin.js
@@ -12,8 +12,42 @@ function getLinguisticCandidates(levelConfig) {
   return base.filter((word) => word.structure !== 'CV-CV-CV');
 }
 
-function createSyllablePieces(syllables) {
-  return shuffleArray(syllables).map((text, index) => ({ id: `${text}-${index}`, text }));
+function hasSameOrder(left, right) {
+  if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((item, index) => item === right[index]);
+}
+
+function ensureReorderedSyllables(syllables, previousOrder = null) {
+  if (!Array.isArray(syllables) || syllables.length <= 1) {
+    return [...syllables];
+  }
+
+  const blockedOrders = [syllables, previousOrder].filter(Boolean);
+
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const candidate = shuffleArray(syllables);
+    const isBlocked = blockedOrders.some((order) => hasSameOrder(candidate, order));
+
+    if (!isBlocked) {
+      return candidate;
+    }
+  }
+
+  const rotated = [...syllables.slice(1), syllables[0]];
+  if (!blockedOrders.some((order) => hasSameOrder(rotated, order))) {
+    return rotated;
+  }
+
+  const reversed = [...syllables].reverse();
+  return reversed;
+}
+
+function createSyllablePieces(syllables, previousOrder = null) {
+  const shuffled = ensureReorderedSyllables(syllables, previousOrder);
+  return shuffled.map((text, index) => ({ id: `${text}-${index}`, text }));
 }
 
 function classifyError({ expected, tapped, submitted, target }) {
@@ -52,7 +86,8 @@ export function createOrderSyllablesPlugin() {
         omision: 0,
         orden_incorrecto: 0
       }
-    }
+    },
+    lastPiecesOrder: null
   };
 
   const recentHistory = createRecentHistory(10);
@@ -87,7 +122,7 @@ export function createOrderSyllablesPlugin() {
         text: word.word,
         syllables: [...word.syllables]
       },
-      pieces: createSyllablePieces(word.syllables),
+      pieces: createSyllablePieces(word.syllables, state.lastPiecesOrder),
       expectedLength: word.syllables.length,
       correctAnswer: word.syllables.join('-')
     };
@@ -112,6 +147,7 @@ export function createOrderSyllablesPlugin() {
 
     state.answer = [];
     state.round = makeRound(state.level);
+    state.lastPiecesOrder = state.round ? state.round.pieces.map((piece) => piece.text) : null;
 
     if (!state.round) {
       return { status: 'empty' };


### PR DESCRIPTION
### Motivation
- Forzar que las sílabas cambien de posición cada vez que se inicia una nueva palabra en el ejercicio de ordenar sílabas, evitando mostrar el mismo orden original o repetir la disposición inmediata anterior en cualquier nivel.

### Description
- Added utility functions `hasSameOrder` and `ensureReorderedSyllables` and used them from `createSyllablePieces` in `src/exercises/orderSyllables.js` to avoid returning the original order when creating pieces. 
- Ported the same reordering logic to the plugin at `src/exercises/orderSyllablesPlugin.js` and added a `lastPiecesOrder` field in the plugin `state` to avoid repeating the previous round's order. 
- `ensureReorderedSyllables` attempts shuffled variants up to 8 times and falls back to a rotation or reversed order when shuffling doesn't produce a different arrangement. 
- Updated calls to `createSyllablePieces` to accept an optional `previousOrder` so the plugin can block the last shown arrangement.

### Testing
- Ran `npm test --silent` which failed because there is no `package.json` in the repository, so no automated test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1d66345c832d817230304a286dc7)