### PR TITLE
Aleatorizar posiciones físicas de sílabas entre palabras

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,9 +28,9 @@ const refs = {
 };
 
 const POSITION_PATTERNS = {
-  2: ['slot-a', 'slot-d'],
-  3: ['slot-a', 'slot-c', 'slot-e'],
-  4: ['slot-a', 'slot-b', 'slot-d', 'slot-f']
+  2: ['slot-a', 'slot-b', 'slot-c', 'slot-d', 'slot-e', 'slot-f', 'slot-g', 'slot-h'],
+  3: ['slot-a', 'slot-b', 'slot-c', 'slot-d', 'slot-e', 'slot-f', 'slot-g', 'slot-h', 'slot-i', 'slot-j'],
+  4: ['slot-a', 'slot-b', 'slot-c', 'slot-d', 'slot-e', 'slot-f', 'slot-g', 'slot-h', 'slot-i', 'slot-j', 'slot-k', 'slot-l']
 };
 
 const SESSION_WORDS_TARGET = 15;
@@ -40,7 +40,8 @@ const state = {
   currentLevel: 1,
   currentMode: 'normal',
   completedWords: 0,
-  isSessionFinished: false
+  isSessionFinished: false,
+  lastSlotsByPieceCount: {}
 };
 const registry = createExerciseRegistry();
 registry.register(createOrderSyllablesPlugin());
@@ -67,6 +68,36 @@ function shuffleLayoutSlots(slots) {
   return shuffled;
 }
 
+function pickRoundSlots(pieceCount) {
+  const availableSlots = getLayoutClass(pieceCount);
+  const previousSlots = state.lastSlotsByPieceCount[pieceCount] ?? [];
+  const shuffled = shuffleLayoutSlots(availableSlots);
+  const selected = [];
+
+  for (const slot of shuffled) {
+    if (selected.length >= pieceCount) {
+      break;
+    }
+    if (!previousSlots.includes(slot)) {
+      selected.push(slot);
+    }
+  }
+
+  if (selected.length < pieceCount) {
+    for (const slot of shuffled) {
+      if (selected.length >= pieceCount) {
+        break;
+      }
+      if (!selected.includes(slot)) {
+        selected.push(slot);
+      }
+    }
+  }
+
+  state.lastSlotsByPieceCount[pieceCount] = selected;
+  return selected;
+}
+
 
 function updateProgress() {
   const progress = Math.min(state.completedWords, SESSION_WORDS_TARGET);
@@ -79,6 +110,7 @@ function updateProgress() {
 function resetSessionProgress() {
   state.completedWords = 0;
   state.isSessionFinished = false;
+  state.lastSlotsByPieceCount = {};
   refs.score.textContent = '0';
   updateProgress();
 }
@@ -102,7 +134,7 @@ function renderRound(viewModel) {
 
   const piecesWrap = document.createElement('div');
   piecesWrap.className = 'pieces-cloud';
-  const slots = shuffleLayoutSlots(getLayoutClass(viewModel.pieces.length));
+  const slots = pickRoundSlots(viewModel.pieces.length);
 
   viewModel.pieces.forEach((piece, index) => {
     const button = document.createElement('button');

--- a/style.css
+++ b/style.css
@@ -321,6 +321,12 @@ h2 { font-size: clamp(1.05rem, 2vw, 1.32rem); }
 .slot-d { top: 58%; left: 55%; }
 .slot-e { top: 24%; left: 61%; }
 .slot-f { top: 63%; left: 8%; }
+.slot-g { top: 8%; left: 72%; }
+.slot-h { top: 55%; left: 32%; }
+.slot-i { top: 33%; left: 43%; }
+.slot-j { top: 70%; left: 72%; }
+.slot-k { top: 46%; left: 76%; }
+.slot-l { top: 16%; left: 48%; }
 
 .answer-zone {
   background:


### PR DESCRIPTION
### Motivation
- Evitar que las sílabas aparezcan en las mismas posiciones físicas entre palabras consecutivas, aplicable a cualquier nivel y número de sílabas.  
- Mantener memoria por cantidad de sílabas para evitar repetir la misma disposición de slots entre rondas consecutivas.  
- Disponer de más posiciones en pantalla para poder elegir combinaciones distintas sin solapamientos visibles.

### Description
- Amplié `POSITION_PATTERNS` para 2, 3 y 4 sílabas con más slots disponibles (`slot-a`..`slot-l`).
- Implementé `pickRoundSlots(pieceCount)` que elige posiciones para la ronda evitando las usadas en la ronda anterior para la misma cuenta de sílabas y actualiza `state.lastSlotsByPieceCount`.
- Reemplacé el uso directo de `shuffleLayoutSlots(getLayoutClass(...))` en `renderRound` por `pickRoundSlots(...)` y reinicio `state.lastSlotsByPieceCount` en `resetSessionProgress()`.
- Añadí las reglas CSS para `slot-g`..`slot-l` en `style.css` para soportar las nuevas posiciones.

### Testing
- Verifiqué sintaxis estática con `node --check main.js`, que pasó correctamente.  
- Confirmé que los cambios afectaron `main.js` y `style.css` sin errores de ejecución inmediato (archivos actualizados y commit realizado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1f5ae848832dbaff676e720eeee8)