### PR TITLE
Añadir confetti y popup al completar 15 palabras

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,22 @@
     </form>
   </dialog>
 
+
+  <dialog id="round-finish" class="confirm-dialog" aria-labelledby="round-finish-title" aria-describedby="round-finish-text">
+    <form method="dialog" class="confirm-dialog__panel finish-dialog__panel">
+      <p class="confirm-dialog__eyebrow">¡Ronda completada!</p>
+      <h3 id="round-finish-title">Terminaste las 15 palabras 🎉</h3>
+      <p id="round-finish-text">Elige qué quieres hacer ahora.</p>
+      <div class="finish-dialog__actions">
+        <button id="finish-home" class="confirm-dialog__btn is-ghost" value="home">Salir al inicio</button>
+        <button id="finish-change-level" class="confirm-dialog__btn is-ghost" value="levels">Elegir otro nivel</button>
+        <button id="finish-repeat" class="confirm-dialog__btn is-primary" value="repeat">Repetir nivel</button>
+      </div>
+    </form>
+  </dialog>
+
+  <canvas id="confetti-canvas" class="confetti-canvas" aria-hidden="true"></canvas>
+
   <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -24,10 +24,16 @@ const refs = {
   nextBtn: document.querySelector('#next-btn'),
   levelConfirmDialog: document.querySelector('#level-confirm'),
   levelConfirmAccept: document.querySelector('#confirm-accept'),
-  levelConfirmCancel: document.querySelector('#confirm-cancel')
+  levelConfirmCancel: document.querySelector('#confirm-cancel'),
+  finishDialog: document.querySelector('#round-finish'),
+  finishHome: document.querySelector('#finish-home'),
+  finishChangeLevel: document.querySelector('#finish-change-level'),
+  finishRepeat: document.querySelector('#finish-repeat'),
+  confettiCanvas: document.querySelector('#confetti-canvas')
 };
 
 const SESSION_WORDS_TARGET = 15;
+const CONFETTI_DURATION_MS = 2200;
 
 const state = {
   activeExerciseId: null,
@@ -44,6 +50,112 @@ const router = createRouter({ root: refs.appRoot, views: { home: refs.homeScreen
 function setFeedback(message, type = '') {
   refs.feedback.textContent = message;
   refs.feedback.className = `feedback ${type ? `is-${type}` : ''}`;
+}
+
+function runConfetti() {
+  const canvas = refs.confettiCanvas;
+  if (!canvas) return;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  const colors = ['#f94144', '#f3722c', '#f9c74f', '#90be6d', '#43aa8b', '#577590', '#9b5de5'];
+  const pieces = [];
+  const count = 120;
+
+  const resize = () => {
+    const ratio = window.devicePixelRatio || 1;
+    canvas.width = window.innerWidth * ratio;
+    canvas.height = window.innerHeight * ratio;
+    canvas.style.width = `${window.innerWidth}px`;
+    canvas.style.height = `${window.innerHeight}px`;
+    ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+  };
+
+  resize();
+  canvas.classList.add('is-visible');
+
+  for (let i = 0; i < count; i += 1) {
+    pieces.push({
+      x: Math.random() * window.innerWidth,
+      y: -20 - Math.random() * window.innerHeight * 0.5,
+      size: 6 + Math.random() * 10,
+      color: colors[Math.floor(Math.random() * colors.length)],
+      vx: -2 + Math.random() * 4,
+      vy: 2 + Math.random() * 4,
+      tilt: Math.random() * Math.PI,
+      spin: -0.2 + Math.random() * 0.4
+    });
+  }
+
+  const start = performance.now();
+
+  const draw = () => {
+    ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+
+    pieces.forEach((piece) => {
+      piece.x += piece.vx;
+      piece.y += piece.vy;
+      piece.tilt += piece.spin;
+      piece.vy += 0.02;
+
+      ctx.save();
+      ctx.translate(piece.x, piece.y);
+      ctx.rotate(piece.tilt);
+      ctx.fillStyle = piece.color;
+      ctx.fillRect(-piece.size / 2, -piece.size / 2, piece.size, piece.size * 0.62);
+      ctx.restore();
+    });
+
+    if (performance.now() - start < CONFETTI_DURATION_MS) {
+      window.requestAnimationFrame(draw);
+      return;
+    }
+
+    canvas.classList.remove('is-visible');
+    ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+  };
+
+  window.requestAnimationFrame(draw);
+}
+
+function handleRoundFinishedChoice(choice) {
+  if (choice === 'home') {
+    router.navigateHome();
+    document.body.classList.remove('is-activity-mode');
+    setFeedback('');
+    return;
+  }
+
+  if (choice === 'levels') {
+    resetSessionProgress();
+    renderRound(getActivePlugin()?.start({ level: state.currentLevel, mode: state.currentMode, resetScore: true }));
+    setFeedback('Elige otro nivel para empezar una nueva ronda.', 'success');
+    return;
+  }
+
+  resetSessionProgress();
+  renderRound(getActivePlugin()?.start({ level: state.currentLevel, mode: state.currentMode, resetScore: true }));
+  setFeedback('Nueva ronda iniciada. ¡A por otras 15!', 'success');
+}
+
+function showRoundFinishedDialog() {
+  const dialog = refs.finishDialog;
+  if (!dialog || typeof dialog.showModal !== 'function') {
+    handleRoundFinishedChoice(window.confirm('Terminaste la ronda. Aceptar = repetir nivel, Cancelar = salir al inicio.') ? 'repeat' : 'home');
+    return;
+  }
+
+  runConfetti();
+
+  const onClose = () => {
+    dialog.removeEventListener('close', onClose);
+    handleRoundFinishedChoice(dialog.returnValue || 'repeat');
+  };
+
+  dialog.addEventListener('close', onClose);
+  dialog.showModal();
+  refs.finishRepeat?.focus();
 }
 
 
@@ -206,6 +318,7 @@ function handleSyllableTap(button) {
     if (state.completedWords >= SESSION_WORDS_TARGET) {
       state.isSessionFinished = true;
       setFeedback('¡Muy bien! Terminaste el ejercicio de 15 palabras.', 'success');
+      showRoundFinishedDialog();
       return;
     }
 
@@ -219,7 +332,7 @@ function startRound() {
   if (!plugin) return;
 
   if (state.isSessionFinished) {
-    setFeedback('Sesión completada (15/15). Cambia de nivel o vuelve al inicio para comenzar otra.', 'success');
+    setFeedback('Sesión completada (15/15). Elige una opción en el popup para continuar.', 'success');
     return;
   }
 

--- a/src/exercises/orderSyllablesPlugin.js
+++ b/src/exercises/orderSyllablesPlugin.js
@@ -90,7 +90,7 @@ export function createOrderSyllablesPlugin() {
     lastPiecesOrder: null
   };
 
-  const recentHistory = createRecentHistory(10);
+  const recentHistory = createRecentHistory(15);
 
   function getCandidates(level) {
     const config = resolveOrderLevel(level);

--- a/style.css
+++ b/style.css
@@ -462,3 +462,36 @@ button:focus-visible { outline: 3px solid #2f75f3; outline-offset: 2px; }
   border-color: transparent;
   color: #fff;
 }
+
+.finish-dialog__panel h3 {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.finish-dialog__actions {
+  margin-top: 18px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+.finish-dialog__actions .confirm-dialog__btn {
+  width: 100%;
+  justify-self: stretch;
+}
+
+.confetti-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  opacity: 0;
+  z-index: 1200;
+  transition: opacity 200ms ease;
+}
+
+.confetti-canvas.is-visible {
+  opacity: 1;
+}


### PR DESCRIPTION
### Motivation
- Celebrar visualmente cuando el jugador completa la meta de `15` palabras en una sesión para mejorar la retroalimentación positiva. 
- Dar al usuario opciones claras al terminar la ronda (salir al inicio, elegir otro nivel o repetir el nivel). 
- Evitar repeticiones de palabras dentro de la misma ronda de `15` elementos garantizando un historial reciente más largo.

### Description
- Añadido un diálogo de fin de ronda `#round-finish` y un `canvas` `#confetti-canvas` en `index.html` y estilos asociados en `style.css` para el popup y la capa de confetti. 
- Implementadas las funciones `runConfetti()`, `showRoundFinishedDialog()` y `handleRoundFinishedChoice()` en `main.js`, y enlazado el flujo para abrir el popup y lanzar la animación al alcanzar `SESSION_WORDS_TARGET` (`15`). 
- Integrado comportamiento para las opciones del popup: `home` (volver al inicio), `levels` (reiniciar progreso y permitir cambiar nivel) y `repeat` (reiniciar la sesión del mismo nivel con 15 nuevas palabras). 
- Evitado que se repitan palabras dentro de la ronda aumentando el historial reciente en `src/exercises/orderSyllablesPlugin.js` mediante `createRecentHistory(15)` en lugar de `10`.

### Testing
- Ejecutado `node --check main.js` y la verificación ha pasado correctamente. 
- Ejecutado `node --check src/exercises/orderSyllablesPlugin.js` y la verificación ha pasado correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4253a198832da5057d8bd8783c37)