### PR TITLE
Agregar pipeline para generar candidatas desde Magic Loops

### DIFF
--- a/src/core/generateWordsFromAI.js
+++ b/src/core/generateWordsFromAI.js
@@ -1,0 +1,143 @@
+const MAGIC_LOOPS_ENDPOINT = 'https://magicloops.dev/api/loop/b42d7ccf-12d8-490f-83a6-c2e4d5d29d2e/run';
+const DEFAULT_OUTPUT_PATH = './src/data/imports/newWords.json';
+
+function normalizeWord(value) {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function extractCandidates(payload) {
+  if (Array.isArray(payload)) return payload;
+
+  const collections = [payload?.words, payload?.data, payload?.result, payload?.items, payload?.candidates];
+  for (const collection of collections) {
+    if (Array.isArray(collection)) return collection;
+  }
+
+  return null;
+}
+
+function sanitizeCandidate(rawEntry) {
+  if (!rawEntry || typeof rawEntry !== 'object') return null;
+
+  return {
+    ...rawEntry,
+    word: normalizeWord(rawEntry.word),
+    category: typeof rawEntry.category === 'string' ? rawEntry.category.trim().toLowerCase() : rawEntry.category,
+    structure: typeof rawEntry.structure === 'string' ? rawEntry.structure.trim() : rawEntry.structure,
+    syllables: Array.isArray(rawEntry.syllables)
+      ? rawEntry.syllables.map((item) => normalizeWord(item)).filter(Boolean)
+      : rawEntry.syllables
+  };
+}
+
+function validateBasicStructure(entry) {
+  const issues = [];
+
+  if (!entry.word) issues.push('word vacío');
+  if (!entry.category || typeof entry.category !== 'string') issues.push('category inválido');
+  if (!entry.structure || typeof entry.structure !== 'string') issues.push('structure inválido');
+  if (!Array.isArray(entry.syllables) || entry.syllables.length === 0) issues.push('syllables inválido');
+
+  return issues;
+}
+
+async function persistCandidates(outputPath, words) {
+  const fsModule = await import('node:fs/promises');
+  const content = JSON.stringify(words, null, 2);
+  await fsModule.writeFile(outputPath, `${content}\n`, 'utf8');
+}
+
+export async function generateWordsFromAI({
+  endpoint = MAGIC_LOOPS_ENDPOINT,
+  outputPath = DEFAULT_OUTPUT_PATH,
+  fetchImpl = fetch,
+  onError = console.error,
+  onInfo = console.info,
+  saveToFile = true
+} = {}) {
+  const summary = {
+    endpoint,
+    received: 0,
+    valid: 0,
+    deduplicated: 0,
+    written: false,
+    outputPath,
+    errors: [],
+    rejected: []
+  };
+
+  try {
+    const response = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({})
+    });
+
+    if (!response.ok) {
+      throw new Error(`Magic Loops devolvió ${response.status} ${response.statusText}`);
+    }
+
+    const payload = await response.json();
+    const rawCandidates = extractCandidates(payload);
+
+    if (!rawCandidates) {
+      throw new Error('La respuesta no contiene un array de palabras candidatas.');
+    }
+
+    summary.received = rawCandidates.length;
+
+    const seenWords = new Set();
+    const validCandidates = [];
+
+    rawCandidates.forEach((candidate, index) => {
+      const sanitized = sanitizeCandidate(candidate);
+      const entryLabel = sanitized?.word || `index:${index}`;
+
+      if (!sanitized) {
+        summary.rejected.push({ index, word: entryLabel, reason: 'entry inválido' });
+        return;
+      }
+
+      const issues = validateBasicStructure(sanitized);
+      if (issues.length > 0) {
+        summary.rejected.push({ index, word: entryLabel, reason: issues.join(', ') });
+        return;
+      }
+
+      if (seenWords.has(sanitized.word)) {
+        summary.deduplicated += 1;
+        return;
+      }
+
+      seenWords.add(sanitized.word);
+      validCandidates.push(sanitized);
+    });
+
+    summary.valid = validCandidates.length;
+
+    if (saveToFile) {
+      await persistCandidates(outputPath, validCandidates);
+      summary.written = true;
+    }
+
+    onInfo('[AI WORDS] Pipeline completado.', {
+      received: summary.received,
+      valid: summary.valid,
+      deduplicated: summary.deduplicated,
+      rejected: summary.rejected.length,
+      written: summary.written,
+      outputPath
+    });
+
+    if (summary.rejected.length > 0) {
+      onError('[AI WORDS] Candidatas rechazadas:', summary.rejected);
+    }
+  } catch (error) {
+    summary.errors.push(error.message);
+    onError('[AI WORDS] Error en generación/importación de candidatas:', error);
+  }
+
+  return summary;
+}
+
+export { MAGIC_LOOPS_ENDPOINT, DEFAULT_OUTPUT_PATH };


### PR DESCRIPTION
### Motivation
- Añadir un paso semiautomático que consulte Magic Loops y produzca lotes de palabras candidatas sin integrarlas directamente en el runtime del juego.
- Garantizar que las candidatas pasen por validación y deduplicación antes de persistirlas para revisión e importación posterior.

### Description
- Se agregó el archivo `src/core/generateWordsFromAI.js` que expone `generateWordsFromAI` y constantes `MAGIC_LOOPS_ENDPOINT` y `DEFAULT_OUTPUT_PATH`.
- El módulo normaliza y sanitiza cada entrada, extrae el array de candidatas de varias posibles propiedades de la respuesta y aplica validación básica de estructura (`word`, `category`, `structure`, `syllables`).
- Se implementó deduplicación por palabra normalizada y generación de un resumen con rechazos y errores, y se persisten las candidatas limpias en `src/data/imports/newWords.json` cuando `saveToFile` está habilitado.
- El módulo usa `fetch` inyectable (`fetchImpl`) y callbacks `onInfo`/`onError` para facilitar pruebas y logging sin acoplarlo al runtime del juego.

### Testing
- Verificado que el módulo se puede importar con Node y que exporta las claves esperadas ejecutando `node --input-type=module -e "import('./src/core/generateWordsFromAI.js').then(m=>console.log(Object.keys(m)))"`, lo que mostró los exports sin errores.
- Importación en modo módulo confirmada sin excepciones y `generateWordsFromAI` devuelve un resumen estructurado cuando se ejecuta en un entorno controlado (simulación/uso de `fetchImpl`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c61e4da90832db942c8376d4fce54)