### PR TITLE
Align word IDs to Spanish categories, relax structure regex, and normalize word comparisons

### DIFF
--- a/src/core/validateWords.js
+++ b/src/core/validateWords.js
@@ -2,7 +2,14 @@ const ALLOWED_CATEGORIES = new Set(['animales', 'hogar', 'comida', 'escuela', 'c
 const ALLOWED_DIFFICULTIES = new Set([1, 2, 3, 4]);
 const ALLOWED_FREQUENCIES = new Set([1, 2, 3]);
 const ID_PATTERN = /^lvl(\d+)_([a-z]+)_([a-z0-9áéíóúüñ]+)$/i;
-const STRUCTURE_PATTERN = /^(CV|CVC|VC)(-(CV|CVC|VC))*$/;
+const STRUCTURE_PATTERN = /^[CV]+(-[CV]+)*$/;
+
+function normalizeComparableText(value) {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
 
 function logWordsError(message) {
   console.error('[WORDS ERROR]');
@@ -129,7 +136,7 @@ export function validateWords(words) {
         warnings += 1;
         logWordsWarning(`ID category and category mismatch in ${entry.id}`);
       }
-      if (entry.word && wordId !== entry.word.toLowerCase()) {
+      if (entry.word && normalizeComparableText(wordId) !== normalizeComparableText(entry.word)) {
         warnings += 1;
         logWordsWarning(`ID word segment and word mismatch in ${entry.id}`);
       }

--- a/src/data/words/animals.js
+++ b/src/data/words/animals.js
@@ -1,6 +1,6 @@
 export const level1Animals = [
   {
-    id: "lvl1_animal_pato",
+    id: "lvl1_animales_pato",
     word: "pato",
     syllables: ["pa", "to"],
     syllableCount: 2,
@@ -13,7 +13,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_gato",
+    id: "lvl1_animales_gato",
     word: "gato",
     syllables: ["ga", "to"],
     syllableCount: 2,
@@ -26,7 +26,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_mono",
+    id: "lvl1_animales_mono",
     word: "mono",
     syllables: ["mo", "no"],
     syllableCount: 2,
@@ -39,7 +39,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_sapo",
+    id: "lvl1_animales_sapo",
     word: "sapo",
     syllables: ["sa", "po"],
     syllableCount: 2,
@@ -52,7 +52,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_lobo",
+    id: "lvl1_animales_lobo",
     word: "lobo",
     syllables: ["lo", "bo"],
     syllableCount: 2,
@@ -65,7 +65,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_vaca",
+    id: "lvl1_animales_vaca",
     word: "vaca",
     syllables: ["va", "ca"],
     syllableCount: 2,
@@ -78,7 +78,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_foca",
+    id: "lvl1_animales_foca",
     word: "foca",
     syllables: ["fo", "ca"],
     syllableCount: 2,
@@ -91,7 +91,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_rana",
+    id: "lvl1_animales_rana",
     word: "rana",
     syllables: ["ra", "na"],
     syllableCount: 2,
@@ -104,7 +104,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_puma",
+    id: "lvl1_animales_puma",
     word: "puma",
     syllables: ["pu", "ma"],
     syllableCount: 2,
@@ -117,21 +117,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_foca",
-    word: "foca",
-    syllables: ["fo", "ca"],
-    syllableCount: 2,
-    initialSyllable: "fo",
-    finalSyllable: "ca",
-    difficulty: 1,
-    frequency: 2,
-    category: "animales",
-    structure: "CV-CV",
-    image: null
-  },
-
-  {
-    id: "lvl1_animal_conejo",
+    id: "lvl1_animales_conejo",
     word: "conejo",
     syllables: ["co", "ne", "jo"],
     syllableCount: 3,
@@ -144,7 +130,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_oveja",
+    id: "lvl1_animales_oveja",
     word: "oveja",
     syllables: ["o", "ve", "ja"],
     syllableCount: 3,
@@ -157,7 +143,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_ballena",
+    id: "lvl1_animales_ballena",
     word: "ballena",
     syllables: ["ba", "lle", "na"],
     syllableCount: 3,
@@ -170,7 +156,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_mariposa",
+    id: "lvl1_animales_mariposa",
     word: "mariposa",
     syllables: ["ma", "ri", "po", "sa"],
     syllableCount: 4,
@@ -183,7 +169,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_gusano",
+    id: "lvl1_animales_gusano",
     word: "gusano",
     syllables: ["gu", "sa", "no"],
     syllableCount: 3,
@@ -196,7 +182,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_paloma",
+    id: "lvl1_animales_paloma",
     word: "paloma",
     syllables: ["pa", "lo", "ma"],
     syllableCount: 3,
@@ -209,7 +195,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_tortuga",
+    id: "lvl1_animales_tortuga",
     word: "tortuga",
     syllables: ["tor", "tu", "ga"],
     syllableCount: 3,
@@ -222,7 +208,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_caballo",
+    id: "lvl1_animales_caballo",
     word: "caballo",
     syllables: ["ca", "ba", "llo"],
     syllableCount: 3,
@@ -235,7 +221,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_pollito",
+    id: "lvl1_animales_pollito",
     word: "pollito",
     syllables: ["po", "lli", "to"],
     syllableCount: 3,
@@ -248,7 +234,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_abeja",
+    id: "lvl1_animales_abeja",
     word: "abeja",
     syllables: ["a", "be", "ja"],
     syllableCount: 3,
@@ -262,7 +248,7 @@ export const level1Animals = [
   },
 
   {
-    id: "lvl1_animal_burro",
+    id: "lvl1_animales_burro",
     word: "burro",
     syllables: ["bu", "rro"],
     syllableCount: 2,
@@ -275,7 +261,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_cebra",
+    id: "lvl1_animales_cebra",
     word: "cebra",
     syllables: ["ce", "bra"],
     syllableCount: 2,
@@ -288,7 +274,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_tigre",
+    id: "lvl1_animales_tigre",
     word: "tigre",
     syllables: ["ti", "gre"],
     syllableCount: 2,
@@ -301,7 +287,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_leon",
+    id: "lvl1_animales_leon",
     word: "león",
     syllables: ["le", "ón"],
     syllableCount: 2,
@@ -314,7 +300,7 @@ export const level1Animals = [
     image: null
   },
   {
-    id: "lvl1_animal_ratón",
+    id: "lvl1_animales_ratón",
     word: "ratón",
     syllables: ["ra", "tón"],
     syllableCount: 2,

--- a/src/data/words/food.js
+++ b/src/data/words/food.js
@@ -1,6 +1,6 @@
 export const level1Food = [
   {
-    id: "lvl1_food_sopa",
+    id: "lvl1_comida_sopa",
     word: "sopa",
     syllables: ["so", "pa"],
     syllableCount: 2,
@@ -13,7 +13,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_papa",
+    id: "lvl1_comida_papa",
     word: "papa",
     syllables: ["pa", "pa"],
     syllableCount: 2,
@@ -26,7 +26,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_queso",
+    id: "lvl1_comida_queso",
     word: "queso",
     syllables: ["que", "so"],
     syllableCount: 2,
@@ -39,7 +39,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_mango",
+    id: "lvl1_comida_mango",
     word: "mango",
     syllables: ["man", "go"],
     syllableCount: 2,
@@ -52,7 +52,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_melon",
+    id: "lvl1_comida_melon",
     word: "melón",
     syllables: ["me", "lón"],
     syllableCount: 2,
@@ -66,7 +66,7 @@ export const level1Food = [
   },
 
   {
-    id: "lvl1_food_tarta",
+    id: "lvl1_comida_tarta",
     word: "tarta",
     syllables: ["tar", "ta"],
     syllableCount: 2,
@@ -79,20 +79,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_galleta",
-    word: "galleta",
-    syllables: ["ga", "lle", "ta"],
-    syllableCount: 3,
-    initialSyllable: "ga",
-    finalSyllable: "ta",
-    difficulty: 1,
-    frequency: 1,
-    category: "comida",
-    structure: "CV-CV-CV",
-    image: null
-  },
-  {
-    id: "lvl1_food_tomate",
+    id: "lvl1_comida_tomate",
     word: "tomate",
     syllables: ["to", "ma", "te"],
     syllableCount: 3,
@@ -105,7 +92,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_patata",
+    id: "lvl1_comida_patata",
     word: "patata",
     syllables: ["pa", "ta", "ta"],
     syllableCount: 3,
@@ -118,7 +105,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_guiso",
+    id: "lvl1_comida_guiso",
     word: "guiso",
     syllables: ["gui", "so"],
     syllableCount: 2,
@@ -132,7 +119,7 @@ export const level1Food = [
   },
 
   {
-    id: "lvl1_food_fresa",
+    id: "lvl1_comida_fresa",
     word: "fresa",
     syllables: ["fre", "sa"],
     syllableCount: 2,
@@ -145,7 +132,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_platano",
+    id: "lvl1_comida_platano",
     word: "plátano",
     syllables: ["plá", "ta", "no"],
     syllableCount: 3,
@@ -158,7 +145,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_naranja",
+    id: "lvl1_comida_naranja",
     word: "naranja",
     syllables: ["na", "ran", "ja"],
     syllableCount: 3,
@@ -171,7 +158,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_manzana",
+    id: "lvl1_comida_manzana",
     word: "manzana",
     syllables: ["man", "za", "na"],
     syllableCount: 3,
@@ -184,7 +171,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_pera",
+    id: "lvl1_comida_pera",
     word: "pera",
     syllables: ["pe", "ra"],
     syllableCount: 2,
@@ -198,7 +185,7 @@ export const level1Food = [
   },
 
   {
-    id: "lvl1_food_kiwi",
+    id: "lvl1_comida_kiwi",
     word: "kiwi",
     syllables: ["ki", "wi"],
     syllableCount: 2,
@@ -211,7 +198,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_limon",
+    id: "lvl1_comida_limon",
     word: "limón",
     syllables: ["li", "món"],
     syllableCount: 2,
@@ -224,7 +211,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_harina",
+    id: "lvl1_comida_harina",
     word: "harina",
     syllables: ["ha", "ri", "na"],
     syllableCount: 3,
@@ -237,7 +224,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_galleta",
+    id: "lvl1_comida_galleta",
     word: "galleta",
     syllables: ["ga", "lle", "ta"],
     syllableCount: 3,
@@ -250,7 +237,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_churro",
+    id: "lvl1_comida_churro",
     word: "churro",
     syllables: ["chu", "rro"],
     syllableCount: 2,
@@ -264,7 +251,7 @@ export const level1Food = [
   },
 
   {
-    id: "lvl1_food_pescado",
+    id: "lvl1_comida_pescado",
     word: "pescado",
     syllables: ["pes", "ca", "do"],
     syllableCount: 3,
@@ -277,7 +264,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_yogur",
+    id: "lvl1_comida_yogur",
     word: "yogur",
     syllables: ["yo", "gur"],
     syllableCount: 2,
@@ -290,7 +277,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_helado",
+    id: "lvl1_comida_helado",
     word: "helado",
     syllables: ["he", "la", "do"],
     syllableCount: 3,
@@ -303,7 +290,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_pan",
+    id: "lvl1_comida_pan",
     word: "pan",
     syllables: ["pan"],
     syllableCount: 1,
@@ -316,7 +303,7 @@ export const level1Food = [
     image: null
   },
   {
-    id: "lvl1_food_arroz",
+    id: "lvl1_comida_arroz",
     word: "arroz",
     syllables: ["a", "rroz"],
     syllableCount: 2,

--- a/src/data/words/home.js
+++ b/src/data/words/home.js
@@ -1,6 +1,6 @@
 export const level1Home = [
   {
-    id: "lvl1_home_casa",
+    id: "lvl1_hogar_casa",
     word: "casa",
     syllables: ["ca", "sa"],
     syllableCount: 2,
@@ -13,7 +13,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_mesa",
+    id: "lvl1_hogar_mesa",
     word: "mesa",
     syllables: ["me", "sa"],
     syllableCount: 2,
@@ -26,7 +26,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_cama",
+    id: "lvl1_hogar_cama",
     word: "cama",
     syllables: ["ca", "ma"],
     syllableCount: 2,
@@ -39,7 +39,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_silla",
+    id: "lvl1_hogar_silla",
     word: "silla",
     syllables: ["si", "lla"],
     syllableCount: 2,
@@ -52,7 +52,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_taza",
+    id: "lvl1_hogar_taza",
     word: "taza",
     syllables: ["ta", "za"],
     syllableCount: 2,
@@ -66,7 +66,7 @@ export const level1Home = [
   },
 
   {
-    id: "lvl1_home_caja",
+    id: "lvl1_hogar_caja",
     word: "caja",
     syllables: ["ca", "ja"],
     syllableCount: 2,
@@ -79,7 +79,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_puerta",
+    id: "lvl1_hogar_puerta",
     word: "puerta",
     syllables: ["puer", "ta"],
     syllableCount: 2,
@@ -92,7 +92,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_techo",
+    id: "lvl1_hogar_techo",
     word: "techo",
     syllables: ["te", "cho"],
     syllableCount: 2,
@@ -105,7 +105,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_suelo",
+    id: "lvl1_hogar_suelo",
     word: "suelo",
     syllables: ["sue", "lo"],
     syllableCount: 2,
@@ -118,7 +118,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_lámpara",
+    id: "lvl1_hogar_lámpara",
     word: "lámpara",
     syllables: ["lám", "pa", "ra"],
     syllableCount: 3,
@@ -132,7 +132,7 @@ export const level1Home = [
   },
 
   {
-    id: "lvl1_home_ventana",
+    id: "lvl1_hogar_ventana",
     word: "ventana",
     syllables: ["ven", "ta", "na"],
     syllableCount: 3,
@@ -145,7 +145,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_cocina",
+    id: "lvl1_hogar_cocina",
     word: "cocina",
     syllables: ["co", "ci", "na"],
     syllableCount: 3,
@@ -158,7 +158,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_cortina",
+    id: "lvl1_hogar_cortina",
     word: "cortina",
     syllables: ["cor", "ti", "na"],
     syllableCount: 3,
@@ -171,7 +171,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_armario",
+    id: "lvl1_hogar_armario",
     word: "armario",
     syllables: ["ar", "ma", "rio"],
     syllableCount: 3,
@@ -184,7 +184,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_espejo",
+    id: "lvl1_hogar_espejo",
     word: "espejo",
     syllables: ["es", "pe", "jo"],
     syllableCount: 3,
@@ -198,7 +198,7 @@ export const level1Home = [
   },
 
   {
-    id: "lvl1_home_alfombra",
+    id: "lvl1_hogar_alfombra",
     word: "alfombra",
     syllables: ["al", "fom", "bra"],
     syllableCount: 3,
@@ -211,7 +211,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_cojín",
+    id: "lvl1_hogar_cojín",
     word: "cojín",
     syllables: ["co", "jín"],
     syllableCount: 2,
@@ -224,7 +224,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_sabana",
+    id: "lvl1_hogar_sabana",
     word: "sábana",
     syllables: ["sá", "ba", "na"],
     syllableCount: 3,
@@ -237,7 +237,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_toalla",
+    id: "lvl1_hogar_toalla",
     word: "toalla",
     syllables: ["to", "a", "lla"],
     syllableCount: 3,
@@ -250,7 +250,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_jabón",
+    id: "lvl1_hogar_jabón",
     word: "jabón",
     syllables: ["ja", "bón"],
     syllableCount: 2,
@@ -264,7 +264,7 @@ export const level1Home = [
   },
 
   {
-    id: "lvl1_home_basura",
+    id: "lvl1_hogar_basura",
     word: "basura",
     syllables: ["ba", "su", "ra"],
     syllableCount: 3,
@@ -277,7 +277,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_estufa",
+    id: "lvl1_hogar_estufa",
     word: "estufa",
     syllables: ["es", "tu", "fa"],
     syllableCount: 3,
@@ -290,7 +290,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_cepillo",
+    id: "lvl1_hogar_cepillo",
     word: "cepillo",
     syllables: ["ce", "pi", "llo"],
     syllableCount: 3,
@@ -303,7 +303,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_cuchara",
+    id: "lvl1_hogar_cuchara",
     word: "cuchara",
     syllables: ["cu", "cha", "ra"],
     syllableCount: 3,
@@ -316,7 +316,7 @@ export const level1Home = [
     image: null
   },
   {
-    id: "lvl1_home_tenedor",
+    id: "lvl1_hogar_tenedor",
     word: "tenedor",
     syllables: ["te", "ne", "dor"],
     syllableCount: 3,


### PR DESCRIPTION
### Motivation
- Standardize dataset IDs to use Spanish category names (`animales`, `comida`, `hogar`) so IDs match entry `category` values.
- Allow more flexible syllable structure tokens beyond the previous limited set to support patterns like `CCV`/`CVV` present in the data.
- Prevent spurious warnings when ID word segments differ only by case or diacritics by comparing words in a normalized, diacritic-insensitive way.

### Description
- Updated many word entry `id` values in `src/data/words/animals.js`, `src/data/words/food.js`, and `src/data/words/home.js` to use Spanish category segments (`lvl1_animales_*`, `lvl1_comida_*`, `lvl1_hogar_*`).
- Removed a duplicate animal entry and cleaned up duplicate/older entries in food data to keep datasets consistent.
- Relaxed the structure pattern in `src/core/validateWords.js` from `/^(CV|CVC|VC)(-(CV|CVC|VC))*$/` to `/^[CV]+(-[CV]+)*$/` to accept arbitrary runs of `C` and `V` tokens per syllable.
- Added `normalizeComparableText` to strip diacritics and lowercase strings, and used it when comparing the ID word segment and the `word` field to avoid false-positive warnings.

### Testing
- Ran the test suite with `npm test` and the run completed successfully.
- Executed the dataset validation (`validateWords`) against the updated word lists and observed no blocking errors and only expected warnings for category mismatches that remain valid; validation completed without failures.
- Linting and basic static checks were run and reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c62f035d4832d9ccac301953afb68)