### PR TITLE
Añadir pantalla admin para generación manual IA e importación controlada

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,44 @@
         <p id="feedback" class="feedback" aria-live="polite"></p>
       </footer>
     </section>
+
+    <section id="admin-screen" class="view panel admin-screen" aria-label="Admin de corpus IA">
+      <p class="eyebrow">Herramienta interna</p>
+      <h2>Admin · Generación IA</h2>
+      <p class="subtitle">Genera candidatas con Magic Loops, revisa resultados y decide importación manual.</p>
+
+      <form id="admin-ai-form" class="admin-form">
+        <label>Categoría
+          <input name="category" value="animales" required />
+        </label>
+        <label>Estructura
+          <input name="structure" value="CV-CV" required />
+        </label>
+        <label>Dificultad
+          <input name="difficulty" type="number" min="1" max="4" value="1" required />
+        </label>
+        <label>Frequency
+          <input name="frequency" type="number" min="1" max="3" value="1" required />
+        </label>
+        <label>Número de palabras
+          <input name="count" type="number" min="1" max="100" value="20" required />
+        </label>
+        <div class="admin-actions">
+          <button id="generate-ai-batch-btn" type="submit" class="secondary-btn">Generar lote IA</button>
+          <button id="import-valid-btn" type="button" class="secondary-btn" disabled>Importar palabras válidas</button>
+        </div>
+      </form>
+
+      <p id="admin-status" class="admin-status" aria-live="polite"></p>
+      <ul id="admin-summary" class="admin-summary"></ul>
+
+      <div class="admin-preview-grid">
+        <section><h3>Válidas</h3><ul id="admin-valid-list"></ul></section>
+        <section><h3>Duplicadas</h3><ul id="admin-duplicate-list"></ul></section>
+        <section><h3>Inválidas</h3><ul id="admin-invalid-list"></ul></section>
+      </div>
+    </section>
+
   </div>
 
   <dialog id="level-confirm" class="confirm-dialog" aria-labelledby="confirm-title" aria-describedby="confirm-text">

--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
       <h1>LEXIA</h1>
       <p class="subtitle">Una experiencia interactiva para practicar habilidades lingüísticas con ejercicios breves, claros y progresivos.</p>
 
+      <div class="home-admin-link-wrap">
+        <a class="home-admin-link" data-open-admin="true" href="#/admin" aria-label="Abrir herramienta interna de administración">Admin interno IA</a>
+      </div>
+
       <nav class="exercise-menu" aria-label="Menú de ejercicios">
         <button type="button" class="exercise-card" data-exercise="order-syllables">
           <strong>Ordenar sílabas</strong>

--- a/main.js
+++ b/main.js
@@ -416,7 +416,13 @@ async function init() {
   await importWordsFromJson();
   validateWords(WORDS);
 
-  const homeController = createHomeController({ homeScreen: refs.homeScreen, onSelectExercise: openExercise });
+  const homeController = createHomeController({
+    homeScreen: refs.homeScreen,
+    onSelectExercise: openExercise,
+    onOpenAdmin: () => {
+      window.location.hash = '/admin';
+    }
+  });
   homeController.bindEvents();
 
   const adminController = createAdminController({ adminScreen: refs.adminScreen });

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 import { validateWords } from './src/core/validateWords.js';
 import { WORDS } from './src/data/words/index.js';
 import { createHomeController } from './src/ui/home.js';
+import { createAdminController } from './src/ui/admin.js';
 import { createRouter } from './src/navigation/router.js';
 import { createExerciseRegistry } from './src/core/exerciseRegistry.js';
 import { createOrderSyllablesPlugin } from './src/exercises/orderSyllablesPlugin.js';
@@ -11,6 +12,7 @@ const refs = {
   appRoot: document.querySelector('#app-root'),
   homeScreen: document.querySelector('#home-screen'),
   exerciseScreen: document.querySelector('#exercise-screen'),
+  adminScreen: document.querySelector('#admin-screen'),
   homeBtn: document.querySelector('#home-btn'),
   levelButtons: document.querySelectorAll('.level-btn'),
   modeButtons: document.querySelectorAll('.mode-btn'),
@@ -46,7 +48,7 @@ const state = {
 const registry = createExerciseRegistry();
 registry.register(createOrderSyllablesPlugin());
 
-const router = createRouter({ root: refs.appRoot, views: { home: refs.homeScreen, exercise: refs.exerciseScreen } });
+const router = createRouter({ root: refs.appRoot, views: { home: refs.homeScreen, exercise: refs.exerciseScreen, admin: refs.adminScreen } });
 
 function setFeedback(message, type = '') {
   refs.feedback.textContent = message;
@@ -417,6 +419,9 @@ async function init() {
   const homeController = createHomeController({ homeScreen: refs.homeScreen, onSelectExercise: openExercise });
   homeController.bindEvents();
 
+  const adminController = createAdminController({ adminScreen: refs.adminScreen });
+  adminController.bindEvents();
+
   refs.levelButtons.forEach((button) => {
     button.addEventListener('click', () => {
       void setLevel(Number(button.dataset.level));
@@ -442,7 +447,22 @@ async function init() {
   });
 
   updateProgress();
+
+  const syncRouteFromHash = () => {
+    const route = window.location.hash.replace('#/', '');
+    if (route === 'admin') {
+      router.navigateAdmin();
+      document.body.classList.remove('is-activity-mode');
+      return;
+    }
+
+    router.navigateHome();
+  };
+
+  window.addEventListener('hashchange', syncRouteFromHash);
+
   router.init('home');
+  syncRouteFromHash();
   document.body.classList.remove('is-activity-mode');
 }
 

--- a/src/core/generateWordsFromAI.js
+++ b/src/core/generateWordsFromAI.js
@@ -53,7 +53,8 @@ export async function generateWordsFromAI({
   fetchImpl = fetch,
   onError = console.error,
   onInfo = console.info,
-  saveToFile = true
+  saveToFile = true,
+  requestPayload = {}
 } = {}) {
   const summary = {
     endpoint,
@@ -63,14 +64,15 @@ export async function generateWordsFromAI({
     written: false,
     outputPath,
     errors: [],
-    rejected: []
+    rejected: [],
+    candidates: []
   };
 
   try {
     const response = await fetchImpl(endpoint, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({})
+      body: JSON.stringify(requestPayload)
     });
 
     if (!response.ok) {
@@ -114,6 +116,7 @@ export async function generateWordsFromAI({
     });
 
     summary.valid = validCandidates.length;
+    summary.candidates = validCandidates;
 
     if (saveToFile) {
       await persistCandidates(outputPath, validCandidates);

--- a/src/core/importWords.js
+++ b/src/core/importWords.js
@@ -61,6 +61,62 @@ function buildId(entry) {
   return `lvl${entry.difficulty}_${entry.category}_${entry.word}`;
 }
 
+export function importWordsFromArray(payload) {
+  const summary = { added: [], rejected: [], errors: [] };
+
+  if (!Array.isArray(payload)) {
+    summary.errors.push('El JSON de importación debe ser un array.');
+    return summary;
+  }
+
+  const existingIds = new Set(WORDS.map((entry) => entry.id));
+  const existingWords = new Set(WORDS.map((entry) => normalizeText(entry.word)));
+
+  payload.forEach((rawEntry, index) => {
+    const sanitized = sanitizeWordEntry(rawEntry);
+    const id = buildId(sanitized);
+
+    if (existingWords.has(sanitized.word)) {
+      const reason = `Duplicado detectado: "${sanitized.word}" ya existe. Se omite.`;
+      summary.rejected.push({ index, word: sanitized.word || `index:${index}`, reason });
+      console.warn(`[WORDS IMPORT][SKIP] ${reason}`);
+      return;
+    }
+
+    const validationErrors = validateImportEntry(sanitized);
+
+    if (existingIds.has(id)) {
+      validationErrors.push(`ID duplicado generado automáticamente: ${id}.`);
+    }
+
+    if (validationErrors.length > 0) {
+      summary.rejected.push({ index, word: sanitized.word || `index:${index}`, reason: validationErrors.join(' ') });
+      return;
+    }
+
+    const nextWord = {
+      id,
+      word: sanitized.word,
+      syllables: sanitized.syllables,
+      syllableCount: sanitized.syllableCount,
+      initialSyllable: sanitized.initialSyllable,
+      finalSyllable: sanitized.finalSyllable,
+      difficulty: sanitized.difficulty,
+      frequency: sanitized.frequency,
+      category: sanitized.category,
+      structure: sanitized.structure,
+      image: sanitized.image ?? null
+    };
+
+    WORDS.push(nextWord);
+    existingIds.add(id);
+    existingWords.add(sanitized.word);
+    summary.added.push(nextWord);
+  });
+
+  return summary;
+}
+
 export async function importWordsFromJson(jsonPath = './src/data/imports/newWords.json') {
   const summary = { added: [], rejected: [], errors: [] };
 
@@ -69,52 +125,10 @@ export async function importWordsFromJson(jsonPath = './src/data/imports/newWord
     if (!response.ok) throw new Error(`No se pudo leer ${jsonPath} (${response.status}).`);
 
     const payload = await response.json();
-    if (!Array.isArray(payload)) throw new Error('El JSON de importación debe ser un array.');
-
-    const existingIds = new Set(WORDS.map((entry) => entry.id));
-    const existingWords = new Set(WORDS.map((entry) => normalizeText(entry.word)));
-
-    payload.forEach((rawEntry, index) => {
-      const sanitized = sanitizeWordEntry(rawEntry);
-      const id = buildId(sanitized);
-
-      if (existingWords.has(sanitized.word)) {
-        const reason = `Duplicado detectado: "${sanitized.word}" ya existe. Se omite.`;
-        summary.rejected.push({ index, word: sanitized.word || `index:${index}`, reason });
-        console.warn(`[WORDS IMPORT][SKIP] ${reason}`);
-        return;
-      }
-
-      const validationErrors = validateImportEntry(sanitized);
-
-      if (existingIds.has(id)) {
-        validationErrors.push(`ID duplicado generado automáticamente: ${id}.`);
-      }
-
-      if (validationErrors.length > 0) {
-        summary.rejected.push({ index, word: sanitized.word || `index:${index}`, reason: validationErrors.join(' ') });
-        return;
-      }
-
-      const nextWord = {
-        id,
-        word: sanitized.word,
-        syllables: sanitized.syllables,
-        syllableCount: sanitized.syllableCount,
-        initialSyllable: sanitized.initialSyllable,
-        finalSyllable: sanitized.finalSyllable,
-        difficulty: sanitized.difficulty,
-        frequency: sanitized.frequency,
-        category: sanitized.category,
-        structure: sanitized.structure,
-        image: sanitized.image ?? null
-      };
-
-      WORDS.push(nextWord);
-      existingIds.add(id);
-      existingWords.add(sanitized.word);
-      summary.added.push(nextWord);
-    });
+    const importSummary = importWordsFromArray(payload);
+    summary.added = importSummary.added;
+    summary.rejected = importSummary.rejected;
+    summary.errors = importSummary.errors;
   } catch (error) {
     summary.errors.push(error.message);
     console.error('[WORDS IMPORT][ERROR]', error);

--- a/src/navigation/router.js
+++ b/src/navigation/router.js
@@ -1,6 +1,7 @@
 const VIEWS = {
   home: 'home',
-  exercise: 'exercise'
+  exercise: 'exercise',
+  admin: 'admin'
 };
 
 export function createRouter({ views, root }) {
@@ -47,6 +48,7 @@ export function createRouter({ views, root }) {
     init,
     navigateHome: () => navigate(VIEWS.home),
     navigateExercise: () => navigate(VIEWS.exercise),
+    navigateAdmin: () => navigate(VIEWS.admin),
     getActiveView: () => state.activeView
   };
 }

--- a/src/ui/admin.js
+++ b/src/ui/admin.js
@@ -1,0 +1,165 @@
+import { generateWordsFromAI } from '../core/generateWordsFromAI.js';
+import { WORDS } from '../data/words/index.js';
+import { importWordsFromArray } from '../core/importWords.js';
+
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function createCorpusSet() {
+  return new Set(WORDS.map((entry) => normalizeText(entry.word)).filter(Boolean));
+}
+
+function isStructureValid(structure) {
+  return /^[CV]+(-[CV]+)*$/.test((structure || '').trim());
+}
+
+function hasValidShape(entry) {
+  if (!entry || typeof entry !== 'object') return false;
+  if (!normalizeText(entry.word)) return false;
+  if (!normalizeText(entry.category)) return false;
+  if (typeof entry.structure !== 'string' || !entry.structure.trim()) return false;
+  if (!Array.isArray(entry.syllables) || entry.syllables.length === 0) return false;
+  return true;
+}
+
+export function createAdminController({ adminScreen }) {
+  const refs = {
+    form: adminScreen.querySelector('#admin-ai-form'),
+    generateBtn: adminScreen.querySelector('#generate-ai-batch-btn'),
+    importBtn: adminScreen.querySelector('#import-valid-btn'),
+    status: adminScreen.querySelector('#admin-status'),
+    summary: adminScreen.querySelector('#admin-summary'),
+    validList: adminScreen.querySelector('#admin-valid-list'),
+    duplicateList: adminScreen.querySelector('#admin-duplicate-list'),
+    invalidList: adminScreen.querySelector('#admin-invalid-list')
+  };
+
+  const state = { validCandidates: [] };
+
+  function setStatus(message, type = '') {
+    refs.status.textContent = message;
+    refs.status.className = `admin-status ${type ? `is-${type}` : ''}`;
+  }
+
+  function renderList(target, rows, emptyMessage) {
+    target.innerHTML = '';
+
+    if (rows.length === 0) {
+      const empty = document.createElement('li');
+      empty.textContent = emptyMessage;
+      target.appendChild(empty);
+      return;
+    }
+
+    rows.forEach((row) => {
+      const item = document.createElement('li');
+      item.textContent = row;
+      target.appendChild(item);
+    });
+  }
+
+  function renderPreview(candidates) {
+    const corpusWords = createCorpusSet();
+    const batchWords = new Set();
+    const valid = [];
+    const duplicates = [];
+    const invalid = [];
+
+    candidates.forEach((entry, index) => {
+      const word = normalizeText(entry?.word) || `index:${index}`;
+
+      if (!hasValidShape(entry)) {
+        invalid.push(`${word}: formato básico inválido`);
+        return;
+      }
+
+      if (!isStructureValid(entry.structure)) {
+        invalid.push(`${entry.word}: estructura inválida (${entry.structure})`);
+        return;
+      }
+
+      if (batchWords.has(entry.word) || corpusWords.has(entry.word)) {
+        duplicates.push(`${entry.word}: duplicada en lote/corpus`);
+        return;
+      }
+
+      batchWords.add(entry.word);
+      valid.push(entry);
+    });
+
+    state.validCandidates = valid;
+    refs.importBtn.disabled = valid.length === 0;
+
+    refs.summary.innerHTML = [
+      `<li>Generadas: <strong>${candidates.length}</strong></li>`,
+      `<li>Válidas: <strong>${valid.length}</strong></li>`,
+      `<li>Duplicadas: <strong>${duplicates.length}</strong></li>`,
+      `<li>Rechazadas: <strong>${invalid.length}</strong></li>`
+    ].join('');
+
+    renderList(refs.validList, valid.map((item) => `${item.word} · ${item.category} · ${item.structure}`), 'Sin palabras válidas.');
+    renderList(refs.duplicateList, duplicates, 'Sin duplicados.');
+    renderList(refs.invalidList, invalid, 'Sin errores de estructura.');
+  }
+
+  function mapNetworkError(message) {
+    if (/Failed to fetch|NetworkError/i.test(message)) return 'Error de red/CORS al conectar con Magic Loops.';
+    if (/timeout/i.test(message)) return 'Timeout llamando al endpoint de Magic Loops.';
+    if (/json/i.test(message)) return 'Formato inválido en la respuesta del servicio IA.';
+    return message;
+  }
+
+  async function handleGenerate(event) {
+    event.preventDefault();
+    refs.generateBtn.disabled = true;
+    refs.importBtn.disabled = true;
+    setStatus('Generando lote con IA…', 'working');
+
+    const formData = new FormData(refs.form);
+    const requestPayload = {
+      category: formData.get('category'),
+      structure: formData.get('structure'),
+      difficulty: Number(formData.get('difficulty')),
+      frequency: Number(formData.get('frequency')),
+      count: Number(formData.get('count'))
+    };
+
+    const summary = await generateWordsFromAI({
+      saveToFile: false,
+      requestPayload
+    });
+
+    refs.generateBtn.disabled = false;
+
+    if (summary.errors.length > 0) {
+      setStatus(mapNetworkError(summary.errors[0]), 'error');
+      renderPreview([]);
+      return;
+    }
+
+    renderPreview(summary.candidates || []);
+    setStatus(`Lote generado (${summary.received}). Revisa la preview antes de importar.`, 'success');
+  }
+
+  function handleImport() {
+    const summary = importWordsFromArray(state.validCandidates);
+
+    if (summary.errors.length > 0) {
+      setStatus(summary.errors[0], 'error');
+      return;
+    }
+
+    setStatus(`Importación completada. Añadidas: ${summary.added.length}, rechazadas: ${summary.rejected.length}.`, 'success');
+  }
+
+  function bindEvents() {
+    refs.form.addEventListener('submit', (event) => {
+      void handleGenerate(event);
+    });
+
+    refs.importBtn.addEventListener('click', handleImport);
+  }
+
+  return { bindEvents };
+}

--- a/src/ui/home.js
+++ b/src/ui/home.js
@@ -1,5 +1,6 @@
-export function createHomeController({ homeScreen, onSelectExercise }) {
+export function createHomeController({ homeScreen, onSelectExercise, onOpenAdmin }) {
   const cards = homeScreen.querySelectorAll('[data-exercise]');
+  const adminLink = homeScreen.querySelector('[data-open-admin]');
 
   function bindEvents() {
     cards.forEach((card) => {
@@ -10,6 +11,11 @@ export function createHomeController({ homeScreen, onSelectExercise }) {
 
         onSelectExercise(card.dataset.exercise);
       });
+    });
+
+    adminLink?.addEventListener('click', (event) => {
+      event.preventDefault();
+      onOpenAdmin();
     });
   }
 

--- a/style.css
+++ b/style.css
@@ -528,3 +528,26 @@ button:focus-visible { outline: 3px solid #2f75f3; outline-offset: 2px; }
 .admin-status { min-height: 24px; margin: 0; font-weight: 700; }
 .admin-status.is-error { color: var(--error); }
 .admin-status.is-success { color: var(--success); }
+
+
+.home-admin-link-wrap {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.home-admin-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px dashed rgba(111, 79, 59, 0.38);
+  color: #5e4b3f;
+  text-decoration: none;
+  font-weight: 800;
+  font-size: .86rem;
+}
+
+.home-admin-link:hover {
+  background: rgba(255, 255, 255, 0.65);
+}

--- a/style.css
+++ b/style.css
@@ -495,3 +495,36 @@ button:focus-visible { outline: 3px solid #2f75f3; outline-offset: 2px; }
 .confetti-canvas.is-visible {
   opacity: 1;
 }
+
+.admin-screen {
+  gap: 14px;
+}
+
+.admin-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 10px;
+}
+
+.admin-form label {
+  display: grid;
+  gap: 6px;
+  font-weight: 700;
+  font-size: .92rem;
+}
+
+.admin-form input {
+  min-height: 38px;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  padding: 0 10px;
+}
+
+.admin-actions { display: flex; gap: 8px; align-items: end; }
+.admin-summary { display: flex; gap: 14px; flex-wrap: wrap; padding-left: 18px; }
+.admin-preview-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+.admin-preview-grid section { border: 1px solid var(--line-soft); border-radius: 12px; background: #fff; padding: 10px; }
+.admin-preview-grid ul { margin: 0; padding-left: 18px; max-height: 190px; overflow: auto; }
+.admin-status { min-height: 24px; margin: 0; font-weight: 700; }
+.admin-status.is-error { color: var(--error); }
+.admin-status.is-success { color: var(--success); }


### PR DESCRIPTION
### Motivation
- Proveer una herramienta interna mínima para generar lotes de palabras con Magic Loops manteniendo control humano y el pipeline de validación existente. 
- Evitar integración automática con el runtime del juego, preservar rendimiento offline y UX sin bloqueos.

### Description
- Añadida vista interna `#/admin` y formulario con controles `category`, `structure`, `difficulty`, `frequency` y `count`, más botones `Generar lote IA` e `Importar palabras válidas` en `index.html` y estilos en `style.css`.
- Nuevo controlador `createAdminController` en `src/ui/admin.js` que llama a `generateWordsFromAI()`, muestra preview separada de válidas/duplicadas/inválidas, y permite importación explícita solo de candidatas válidas.
- `generateWordsFromAI` (en `src/core/generateWordsFromAI.js`) acepta ahora `requestPayload` y devuelve `summary.candidates` sanitizados para preview sin forzar persistencia; la escritura a archivo sigue opcional.
- Se añadió `importWordsFromArray` en `src/core/importWords.js` y `importWordsFromJson` delega ahora en esa función para reutilizar saneado y validación al importar manualmente al corpus en memoria.
- Router extendido (`src/navigation/router.js`) y `main.js` actualizado para registrar la vista/admin controller y soportar navegación por hash (`#/admin`) sin afectar el flujo del juego.

### Testing
- Ejecutado `node --check main.js` — passed.
- Ejecutado `node --check src/ui/admin.js` — passed.
- Ejecutado `node --check src/core/generateWordsFromAI.js` — passed.
- Ejecutado `node --check src/core/importWords.js` — passed.
- Ejecutado `node --check src/navigation/router.js` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c66f380c8832d8a7311bbd08753b8)