### PR TITLE
Implementar pipeline de diccionario español y enriquecimiento automático

### DIFF
--- a/src/core/validateWords.js
+++ b/src/core/validateWords.js
@@ -1,4 +1,4 @@
-const ALLOWED_CATEGORIES = new Set(['animales', 'hogar', 'comida', 'escuela', 'cuerpo', 'juguetes', 'ropa', 'naturaleza']);
+const ALLOWED_CATEGORIES = new Set(['animales', 'hogar', 'comida', 'escuela', 'cuerpo', 'juguetes', 'ropa', 'naturaleza', 'general']);
 const ALLOWED_DIFFICULTIES = new Set([1, 2, 3, 4]);
 const ALLOWED_FREQUENCIES = new Set([1, 2, 3]);
 const ID_PATTERN = /^lvl(\d+)_([a-z]+)_([a-z0-9áéíóúüñ]+)$/i;
@@ -124,6 +124,11 @@ export function validateWords(words) {
     if (entry.finalSyllable !== entry.syllables[entry.syllables.length - 1]) {
       errors += 1;
       logWordsError(`Incorrect finalSyllable in word: ${ref}`);
+    }
+
+    if (entry.needsReview === true) {
+      warnings += 1;
+      logWordsWarning(`Word flagged for manual review: ${ref}`);
     }
 
     if (parsedId) {

--- a/src/core/wordProcessor.js
+++ b/src/core/wordProcessor.js
@@ -1,0 +1,171 @@
+const VOWELS = new Set(['a', 'e', 'i', 'o', 'u', 'á', 'é', 'í', 'ó', 'ú', 'ü']);
+const SIMPLE_STRUCTURES = new Set(['CV-CV', 'CV', 'CVC', 'CV-CVC']);
+
+function normalizeWordValue(value) {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function removeDiacritics(value) {
+  return value.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+function isVowel(char) {
+  return VOWELS.has(char);
+}
+
+export function syllabifySpanishWord(word) {
+  const text = normalizeWordValue(word);
+  if (!text) return { syllables: [], needsReview: true };
+
+  const syllables = [];
+  let buffer = '';
+
+  for (let i = 0; i < text.length; i += 1) {
+    buffer += text[i];
+    const current = text[i];
+    const next = text[i + 1];
+
+    if (!isVowel(current)) continue;
+    if (!next) {
+      syllables.push(buffer);
+      buffer = '';
+      continue;
+    }
+
+    if (isVowel(next)) {
+      syllables.push(buffer);
+      buffer = '';
+      continue;
+    }
+
+    const next2 = text[i + 2];
+    if (!next2) {
+      syllables.push(buffer);
+      buffer = next;
+      i += 1;
+      continue;
+    }
+
+    if (isVowel(next2)) {
+      syllables.push(buffer);
+      buffer = '';
+      continue;
+    }
+
+    const cluster = `${next}${next2}`;
+    const allowedOnsets = new Set(['pr', 'pl', 'br', 'bl', 'tr', 'dr', 'cr', 'cl', 'gr', 'gl', 'fr', 'fl']);
+    if (allowedOnsets.has(cluster)) {
+      syllables.push(buffer);
+      buffer = '';
+      continue;
+    }
+
+    syllables.push(`${buffer}${next}`);
+    buffer = '';
+    i += 1;
+  }
+
+  if (buffer) {
+    if (syllables.length > 0) {
+      syllables[syllables.length - 1] = `${syllables[syllables.length - 1]}${buffer}`;
+    } else {
+      syllables.push(buffer);
+    }
+  }
+
+  const sanitized = syllables.map((item) => item.trim()).filter(Boolean);
+  const joined = sanitized.join('');
+  const needsReview = sanitized.length === 0 || joined !== text || sanitized.some((item) => ![...item].some((char) => isVowel(char)));
+
+  return { syllables: sanitized, needsReview };
+}
+
+export function getSyllableStructure(syllables) {
+  if (!Array.isArray(syllables) || syllables.length === 0) return '';
+
+  return syllables
+    .map((syllable) => [...syllable].map((char) => (isVowel(char) ? 'V' : 'C')).join(''))
+    .join('-');
+}
+
+export function getFrequencyLevel(frequencyRank) {
+  const rank = Number(frequencyRank);
+  if (!Number.isFinite(rank)) return 2;
+  if (rank >= 1 && rank <= 1000) return 1;
+  if (rank <= 5000) return 2;
+  return 3;
+}
+
+export function getDifficultyFromWordData(wordData) {
+  const syllableCount = wordData.syllableCount;
+  const structure = wordData.structure;
+  const frequency = wordData.frequency;
+
+  if (frequency === 3) return 3;
+
+  if (syllableCount <= 2 && SIMPLE_STRUCTURES.has(structure) && (frequency === 1 || frequency === 2)) {
+    return 1;
+  }
+
+  if (syllableCount === 3 && structure === 'CV-CV-CV' && (frequency === 1 || frequency === 2)) {
+    return 2;
+  }
+
+  if (syllableCount >= 3 || structure.includes('CCV') || structure.includes('CC')) {
+    return 3;
+  }
+
+  return 2;
+}
+
+function normalizeForId(word) {
+  return removeDiacritics(word).replace(/[^a-z0-9ñ]/g, '').toLowerCase();
+}
+
+function normalizeRawEntry(rawEntry) {
+  if (typeof rawEntry === 'string') {
+    return { word: normalizeWordValue(rawEntry), frequencyRank: null };
+  }
+
+  return {
+    word: normalizeWordValue(rawEntry?.word),
+    frequencyRank: rawEntry?.frequencyRank ?? null
+  };
+}
+
+export function enrichRawWord(rawEntry, category = 'general') {
+  const base = normalizeRawEntry(rawEntry);
+  const { syllables, needsReview } = syllabifySpanishWord(base.word);
+  const structure = getSyllableStructure(syllables);
+  const frequency = getFrequencyLevel(base.frequencyRank);
+
+  const wordData = {
+    word: base.word,
+    syllables,
+    syllableCount: syllables.length,
+    initialSyllable: syllables[0] ?? '',
+    finalSyllable: syllables[syllables.length - 1] ?? '',
+    frequency,
+    category,
+    structure
+  };
+
+  const difficulty = getDifficultyFromWordData(wordData);
+  const id = `lvl${difficulty}_${category}_${normalizeForId(base.word)}`;
+
+  return {
+    id,
+    ...wordData,
+    difficulty,
+    image: null,
+    needsReview
+  };
+}
+
+export function buildProcessedWords(rawWords, { category = 'general' } = {}) {
+  if (!Array.isArray(rawWords)) return [];
+
+  return rawWords
+    .map((entry) => enrichRawWord(entry, category))
+    .filter((entry) => entry.word && entry.syllables.length > 0 && entry.structure);
+}

--- a/src/data/raw/spanishWords.js
+++ b/src/data/raw/spanishWords.js
@@ -1,0 +1,12 @@
+export const RAW_SPANISH_WORDS = [
+  { word: 'casa', frequencyRank: 120 },
+  { word: 'mesa', frequencyRank: 340 },
+  { word: 'pelota', frequencyRank: 850 },
+  { word: 'plato', frequencyRank: 1100 },
+  { word: 'pan', frequencyRank: 90 },
+  'zapato',
+  'camino',
+  'escuela',
+  'juego',
+  'puerta'
+];

--- a/src/data/raw/spanishWords.json
+++ b/src/data/raw/spanishWords.json
@@ -1,0 +1,12 @@
+[
+  { "word": "casa", "frequencyRank": 120 },
+  { "word": "mesa", "frequencyRank": 340 },
+  { "word": "pelota", "frequencyRank": 850 },
+  { "word": "plato", "frequencyRank": 1100 },
+  { "word": "pan", "frequencyRank": 90 },
+  "zapato",
+  "camino",
+  "escuela",
+  "juego",
+  "puerta"
+]

--- a/src/data/words/index.js
+++ b/src/data/words/index.js
@@ -1,5 +1,12 @@
 import { level1Animals } from './animals.js';
 import { level1Home } from './home.js';
 import { level1Food } from './food.js';
+import { RAW_SPANISH_WORDS } from '../raw/spanishWords.js';
+import { buildProcessedWords } from '../../core/wordProcessor.js';
 
-export const WORDS = [...level1Animals, ...level1Home, ...level1Food];
+const baseWords = [...level1Animals, ...level1Home, ...level1Food];
+const existingWords = new Set(baseWords.map((entry) => entry.word));
+const processedGeneralWords = buildProcessedWords(RAW_SPANISH_WORDS, { category: 'general' })
+  .filter((entry) => !existingWords.has(entry.word));
+
+export const WORDS = [...baseWords, ...processedGeneralWords];


### PR DESCRIPTION
### Motivation
- Añadir la capacidad de consumir listados grandes de palabras reales en español y convertirlos en un corpus enriquecido compatible con el sistema actual. 
- Evitar dependencia de IA en tiempo de ejecución y mantener JavaScript vanilla y arquitectura modular. 
- Mantener la compatibilidad con las palabras manuales existentes y permitir revisión manual de casos dudosos.

### Description
- Se añadió el diccionario bruto en `src/data/raw/spanishWords.json` y su espejo `src/data/raw/spanishWords.js` para consumo directo sin bundler. 
- Se creó `src/core/wordProcessor.js` con el pipeline de enriquecimiento y las funciones principales: `syllabifySpanishWord`, `getSyllableStructure`, `getFrequencyLevel`, `getDifficultyFromWordData`, `enrichRawWord` y `buildProcessedWords`, además de la regla de generación de IDs `lvl{difficulty}_{category}_{normalizedWord}`. 
- Se integró el corpus procesado en `src/data/words/index.js` combinando las palabras manuales existentes con las procesadas y filtrando duplicados por `word` para no romper ejercicios actuales. 
- Se actualizó `src/core/validateWords.js` para aceptar la categoría `general` y registrar `needsReview` como una advertencia para revisión manual posterior.

### Testing
- Se ejecutó la validación automática importando `WORDS` y llamando a `validateWords` con Node usando el comando `node --input-type=module -e "import { WORDS } from './src/data/words/index.js'; import { validateWords } from './src/core/validateWords.js'; const r=validateWords(WORDS); console.log('words', WORDS.length, r);"`, y la ejecución devolvió `errors: 0` y `warnings: 0`, indicando que el dataset resultante es válido bajo las reglas actuales.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c72bea498832db5278a0a3f2f723f)