### PR TITLE
feat(core): implementar silabificación y pipeline de procesamiento de palabras

### DIFF
--- a/src/core/wordProcessor.js
+++ b/src/core/wordProcessor.js
@@ -1,5 +1,11 @@
+import { validateWords } from './validateWords.js';
+
 const VOWELS = new Set(['a', 'e', 'i', 'o', 'u', 'á', 'é', 'í', 'ó', 'ú', 'ü']);
-const SIMPLE_STRUCTURES = new Set(['CV-CV', 'CV', 'CVC', 'CV-CVC']);
+const STRONG_VOWELS = new Set(['a', 'á', 'e', 'é', 'o', 'ó']);
+const SIMPLE_STRUCTURES = new Set(['CV', 'CV-CV', 'CVC', 'CV-CVC', 'CVV', 'CVV-CV']);
+const ALLOWED_ONSETS = new Set([
+  'pr', 'pl', 'br', 'bl', 'tr', 'dr', 'cr', 'cl', 'gr', 'gl', 'fr', 'fl', 'ch', 'll', 'rr'
+]);
 
 function normalizeWordValue(value) {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
@@ -13,69 +19,85 @@ function isVowel(char) {
   return VOWELS.has(char);
 }
 
+function isStrongVowel(char) {
+  return STRONG_VOWELS.has(char);
+}
+
+
+function startsDiphthong(a, b) {
+  if (!isVowel(a) || !isVowel(b)) return false;
+  const aStrong = isStrongVowel(a);
+  const bStrong = isStrongVowel(b);
+
+  // hiato fuerte-fuerte
+  if (aStrong && bStrong) return false;
+  // débil tónica rompe diptongo
+  if ((a === 'í' || a === 'ú') || (b === 'í' || b === 'ú')) return false;
+
+  return true;
+}
+
+function cleanForWord(value) {
+  return normalizeWordValue(value).replace(/[^a-záéíóúüñ]/g, '');
+}
+
 export function syllabifySpanishWord(word) {
-  const text = normalizeWordValue(word);
+  const text = cleanForWord(word);
   if (!text) return { syllables: [], needsReview: true };
 
   const syllables = [];
-  let buffer = '';
+  let cursor = 0;
 
-  for (let i = 0; i < text.length; i += 1) {
-    buffer += text[i];
-    const current = text[i];
-    const next = text[i + 1];
+  while (cursor < text.length) {
+    let onsetEnd = cursor;
+    while (onsetEnd < text.length && !isVowel(text[onsetEnd])) onsetEnd += 1;
 
-    if (!isVowel(current)) continue;
-    if (!next) {
-      syllables.push(buffer);
-      buffer = '';
-      continue;
+    if (onsetEnd >= text.length) {
+      if (syllables.length > 0) {
+        syllables[syllables.length - 1] += text.slice(cursor);
+      } else {
+        syllables.push(text.slice(cursor));
+      }
+      break;
     }
 
-    if (isVowel(next)) {
-      syllables.push(buffer);
-      buffer = '';
-      continue;
+    let nucleusEnd = onsetEnd + 1;
+    if (nucleusEnd < text.length && startsDiphthong(text[nucleusEnd - 1], text[nucleusEnd])) {
+      nucleusEnd += 1;
+      if (nucleusEnd < text.length && startsDiphthong(text[nucleusEnd - 1], text[nucleusEnd])) {
+        nucleusEnd += 1;
+      }
     }
 
-    const next2 = text[i + 2];
-    if (!next2) {
-      syllables.push(buffer);
-      buffer = next;
-      i += 1;
-      continue;
-    }
+    let codaSplit = nucleusEnd;
+    let consonantRunEnd = nucleusEnd;
 
-    if (isVowel(next2)) {
-      syllables.push(buffer);
-      buffer = '';
-      continue;
-    }
+    while (consonantRunEnd < text.length && !isVowel(text[consonantRunEnd])) consonantRunEnd += 1;
 
-    const cluster = `${next}${next2}`;
-    const allowedOnsets = new Set(['pr', 'pl', 'br', 'bl', 'tr', 'dr', 'cr', 'cl', 'gr', 'gl', 'fr', 'fl']);
-    if (allowedOnsets.has(cluster)) {
-      syllables.push(buffer);
-      buffer = '';
-      continue;
-    }
-
-    syllables.push(`${buffer}${next}`);
-    buffer = '';
-    i += 1;
-  }
-
-  if (buffer) {
-    if (syllables.length > 0) {
-      syllables[syllables.length - 1] = `${syllables[syllables.length - 1]}${buffer}`;
+    const run = text.slice(nucleusEnd, consonantRunEnd);
+    if (consonantRunEnd >= text.length) {
+      codaSplit = consonantRunEnd;
+    } else if (run.length <= 1) {
+      codaSplit = nucleusEnd;
+    } else if (run.length === 2 && ALLOWED_ONSETS.has(run)) {
+      codaSplit = nucleusEnd;
+    } else if (run.length === 2) {
+      codaSplit = nucleusEnd + 1;
     } else {
-      syllables.push(buffer);
+      const lastTwo = run.slice(-2);
+      codaSplit = ALLOWED_ONSETS.has(lastTwo) ? consonantRunEnd - 2 : consonantRunEnd - 1;
     }
+
+    syllables.push(text.slice(cursor, codaSplit));
+    cursor = codaSplit;
   }
 
   const sanitized = syllables.map((item) => item.trim()).filter(Boolean);
-  const joined = sanitized.join('');
-  const needsReview = sanitized.length === 0 || joined !== text || sanitized.some((item) => ![...item].some((char) => isVowel(char)));
+  const rejoined = sanitized.join('');
+  const needsReview =
+    rejoined !== text ||
+    sanitized.some((item) => ![...item].some((char) => isVowel(char))) ||
+    sanitized.some((item) => item.length > 6);
 
   return { syllables: sanitized, needsReview };
 }
@@ -92,27 +114,28 @@ export function getFrequencyLevel(frequencyRank) {
   const rank = Number(frequencyRank);
   if (!Number.isFinite(rank)) return 2;
   if (rank >= 1 && rank <= 1000) return 1;
-  if (rank <= 5000) return 2;
+  if (rank >= 1001 && rank <= 5000) return 2;
   return 3;
 }
 
 export function getDifficultyFromWordData(wordData) {
-  const syllableCount = wordData.syllableCount;
-  const structure = wordData.structure;
-  const frequency = wordData.frequency;
+  const syllableCount = Number(wordData?.syllableCount) || 0;
+  const structure = wordData?.structure || '';
+  const frequency = Number(wordData?.frequency) || 2;
 
-  if (frequency === 3) return 3;
+  const hasComplexCluster = structure.includes('CC');
+  const hasMixedStructure = structure.split('-').some((part) => part.length >= 4);
 
-  if (syllableCount <= 2 && SIMPLE_STRUCTURES.has(structure) && (frequency === 1 || frequency === 2)) {
+  if (frequency === 3 || hasComplexCluster || hasMixedStructure || syllableCount >= 4) {
+    return 3;
+  }
+
+  if (syllableCount >= 1 && syllableCount <= 2 && SIMPLE_STRUCTURES.has(structure) && frequency <= 2) {
     return 1;
   }
 
-  if (syllableCount === 3 && structure === 'CV-CV-CV' && (frequency === 1 || frequency === 2)) {
+  if (syllableCount === 3 && frequency <= 2) {
     return 2;
-  }
-
-  if (syllableCount >= 3 || structure.includes('CCV') || structure.includes('CC')) {
-    return 3;
   }
 
   return 2;
@@ -124,18 +147,18 @@ function normalizeForId(word) {
 
 function normalizeRawEntry(rawEntry) {
   if (typeof rawEntry === 'string') {
-    return { word: normalizeWordValue(rawEntry), frequencyRank: null };
+    return { word: cleanForWord(rawEntry), frequencyRank: null };
   }
 
   return {
-    word: normalizeWordValue(rawEntry?.word),
+    word: cleanForWord(rawEntry?.word),
     frequencyRank: rawEntry?.frequencyRank ?? null
   };
 }
 
 export function enrichRawWord(rawEntry, category = 'general') {
   const base = normalizeRawEntry(rawEntry);
-  const { syllables, needsReview } = syllabifySpanishWord(base.word);
+  const { syllables, needsReview: syllableReview } = syllabifySpanishWord(base.word);
   const structure = getSyllableStructure(syllables);
   const frequency = getFrequencyLevel(base.frequencyRank);
 
@@ -152,6 +175,10 @@ export function enrichRawWord(rawEntry, category = 'general') {
 
   const difficulty = getDifficultyFromWordData(wordData);
   const id = `lvl${difficulty}_${category}_${normalizeForId(base.word)}`;
+  const needsReview =
+    syllableReview ||
+    !/^([CV]+)(-[CV]+)*$/.test(structure) ||
+    syllables.some((part) => part.length === 0);
 
   return {
     id,
@@ -162,10 +189,32 @@ export function enrichRawWord(rawEntry, category = 'general') {
   };
 }
 
-export function buildProcessedWords(rawWords, { category = 'general' } = {}) {
+export function buildProcessedWords(rawWords, { category = 'general', validate = true } = {}) {
   if (!Array.isArray(rawWords)) return [];
 
-  return rawWords
+  const seenIds = new Set();
+  const seenWords = new Set();
+
+  const processed = rawWords
     .map((entry) => enrichRawWord(entry, category))
-    .filter((entry) => entry.word && entry.syllables.length > 0 && entry.structure);
+    .filter((entry) => {
+      if (!entry.word || entry.syllables.length === 0 || !entry.structure) return false;
+
+      const duplicateId = seenIds.has(entry.id);
+      const duplicateWord = seenWords.has(entry.word);
+      seenIds.add(entry.id);
+      seenWords.add(entry.word);
+
+      if (duplicateId || duplicateWord) {
+        entry.needsReview = true;
+      }
+
+      return true;
+    });
+
+  if (validate) {
+    validateWords(processed);
+  }
+
+  return processed;
 }


### PR DESCRIPTION
### Motivation
- Añadir un motor lingüístico que transforme entradas crudas (`word`, `frequencyRank`) en palabras jugables compatibles con el corpus y los ejercicios actuales. 
- Automatizar la silabificación y el enriquecimiento léxico para reducir la dependencia de datasets manuales y permitir procesar miles de palabras. 
- Mantener JavaScript vanilla, modularidad y compatibilidad con las validaciones y filtros existentes.

### Description
- Reescritura de `src/core/wordProcessor.js` que exporta `syllabifySpanishWord`, `getSyllableStructure`, `getFrequencyLevel`, `getDifficultyFromWordData`, `enrichRawWord` y `buildProcessedWords`. 
- `syllabifySpanishWord(word)` implementa heurísticas de ataque/núcleo/coda, manejo básico de diptongos/hiatos y reconocimiento de grupos consonánticos permitidos para producir `syllables` y `needsReview`. 
- Genera `structure` en formato `C`/`V`, calcula `frequency` por rango, infiere `difficulty` según reglas iniciales y normaliza IDs con `lvl{difficulty}_{category}_{word}` (sin tildes ni caracteres raros). 
- `buildProcessedWords` procesa lotes, marca duplicados internos con `needsReview`, y opcionalmente invoca `validateWords` para asegurar compatibilidad con las reglas actuales.

### Testing
- Ejecutados comandos Node que verifican casos de ejemplo y la salida esperada de la silabificación para `casa`, `pelota`, `fresa` y `plátano`, y todos devolvieron las sílabas esperadas. 
- Verificada la transformación de ejemplo `enrichRawWord({ word: 'pelota', frequencyRank: 820 })` produciendo `id`, `structure`, `difficulty`, `syllables` y `needsReview` como esperado. 
- Probado `buildProcessedWords` con un par de entradas duplicadas (con `validate:false`) para comprobar que los duplicados se marcan con `needsReview` y que la salida mantiene el formato compatible con el corpus. 
- No se añadieron backend ni dependencias nuevas y la integración está pensada para no romper ejercicios actuales; la validación automática puede activarse mediante el parámetro `validate` en `buildProcessedWords`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c77c62544832db051abb2cf83125f)