### PR TITLE
Unificar flujo de palabras a un único dataset procesado

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,12 +1,11 @@
 import { validateWords } from './src/core/validateWords.js';
-import { WORDS } from './src/data/words/index.js';
+import { WORDS, loadWordsDataset } from './src/data/words/index.js';
 import { createHomeController } from './src/ui/home.js';
 import { createAdminController } from './src/ui/admin.js';
 import { createRouter } from './src/navigation/router.js';
 import { createExerciseRegistry } from './src/core/exerciseRegistry.js';
 import { createOrderSyllablesPlugin } from './src/exercises/orderSyllablesPlugin.js';
 import { ORDER_MODES } from './src/exercises/orderSyllablesConfig.js';
-import { importWordsFromJson } from './src/core/importWords.js';
 
 const refs = {
   appRoot: document.querySelector('#app-root'),
@@ -413,8 +412,9 @@ function openExercise(exerciseId) {
 }
 
 async function init() {
-  await importWordsFromJson();
+  const loadSummary = await loadWordsDataset();
   validateWords(WORDS);
+  console.info('[WORDS FLOW] Validación del juego completada', loadSummary);
 
   const homeController = createHomeController({
     homeScreen: refs.homeScreen,

--- a/scripts/processWords.mjs
+++ b/scripts/processWords.mjs
@@ -1,0 +1,25 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { buildProcessedWords } from '../src/core/wordProcessor.js';
+
+const CORE_PATH = new URL('../src/data/processed/spanishWordsCore.json', import.meta.url);
+const OUTPUT_PATH = new URL('../src/data/processed/processedWords.json', import.meta.url);
+
+async function run() {
+  const rawText = await readFile(CORE_PATH, 'utf8');
+  const coreWords = JSON.parse(rawText);
+
+  console.info(`[WORDS FLOW] Leyendo corpus base: ${CORE_PATH.pathname}`);
+  console.info(`[WORDS FLOW] Entradas en corpus base: ${Array.isArray(coreWords) ? coreWords.length : 0}`);
+
+  const processedWords = buildProcessedWords(coreWords, { validate: true });
+
+  await writeFile(OUTPUT_PATH, `${JSON.stringify(processedWords, null, 2)}\n`, 'utf8');
+
+  console.info(`[WORDS FLOW] processedWords generado en: ${OUTPUT_PATH.pathname}`);
+  console.info(`[WORDS FLOW] Palabras válidas para juego: ${processedWords.length}`);
+}
+
+run().catch((error) => {
+  console.error('[WORDS FLOW] Error al generar processedWords.json', error);
+  process.exitCode = 1;
+});

--- a/src/core/wordProcessor.js
+++ b/src/core/wordProcessor.js
@@ -147,17 +147,19 @@ function normalizeForId(word) {
 
 function normalizeRawEntry(rawEntry) {
   if (typeof rawEntry === 'string') {
-    return { word: cleanForWord(rawEntry), frequencyRank: null };
+    return { word: cleanForWord(rawEntry), frequencyRank: null, category: 'general' };
   }
 
   return {
     word: cleanForWord(rawEntry?.word),
-    frequencyRank: rawEntry?.frequencyRank ?? null
+    frequencyRank: rawEntry?.frequencyRank ?? null,
+    category: normalizeWordValue(rawEntry?.category) || 'general'
   };
 }
 
 export function enrichRawWord(rawEntry, category = 'general') {
   const base = normalizeRawEntry(rawEntry);
+  const resolvedCategory = category === 'general' ? base.category : category;
   const { syllables, needsReview: syllableReview } = syllabifySpanishWord(base.word);
   const structure = getSyllableStructure(syllables);
   const frequency = getFrequencyLevel(base.frequencyRank);
@@ -169,12 +171,12 @@ export function enrichRawWord(rawEntry, category = 'general') {
     initialSyllable: syllables[0] ?? '',
     finalSyllable: syllables[syllables.length - 1] ?? '',
     frequency,
-    category,
+    category: resolvedCategory,
     structure
   };
 
   const difficulty = getDifficultyFromWordData(wordData);
-  const id = `lvl${difficulty}_${category}_${normalizeForId(base.word)}`;
+  const id = `lvl${difficulty}_${resolvedCategory}_${normalizeForId(base.word)}`;
   const needsReview =
     syllableReview ||
     !/^([CV]+)(-[CV]+)*$/.test(structure) ||

--- a/src/data/processed/processedWords.json
+++ b/src/data/processed/processedWords.json
@@ -1,0 +1,87 @@
+[
+  {
+    "id": "lvl3_hogar_casa",
+    "word": "casa",
+    "syllables": [
+      "ca",
+      "sa"
+    ],
+    "syllableCount": 2,
+    "initialSyllable": "ca",
+    "finalSyllable": "sa",
+    "frequency": 3,
+    "category": "hogar",
+    "structure": "CV-CV",
+    "difficulty": 3,
+    "image": null,
+    "needsReview": false
+  },
+  {
+    "id": "lvl3_hogar_mesa",
+    "word": "mesa",
+    "syllables": [
+      "me",
+      "sa"
+    ],
+    "syllableCount": 2,
+    "initialSyllable": "me",
+    "finalSyllable": "sa",
+    "frequency": 3,
+    "category": "hogar",
+    "structure": "CV-CV",
+    "difficulty": 3,
+    "image": null,
+    "needsReview": false
+  },
+  {
+    "id": "lvl3_juguetes_pelota",
+    "word": "pelota",
+    "syllables": [
+      "pe",
+      "lo",
+      "ta"
+    ],
+    "syllableCount": 3,
+    "initialSyllable": "pe",
+    "finalSyllable": "ta",
+    "frequency": 3,
+    "category": "juguetes",
+    "structure": "CV-CV-CV",
+    "difficulty": 3,
+    "image": null,
+    "needsReview": false
+  },
+  {
+    "id": "lvl3_comida_plato",
+    "word": "plato",
+    "syllables": [
+      "pla",
+      "to"
+    ],
+    "syllableCount": 2,
+    "initialSyllable": "pla",
+    "finalSyllable": "to",
+    "frequency": 3,
+    "category": "comida",
+    "structure": "CCV-CV",
+    "difficulty": 3,
+    "image": null,
+    "needsReview": false
+  },
+  {
+    "id": "lvl3_comida_pan",
+    "word": "pan",
+    "syllables": [
+      "pan"
+    ],
+    "syllableCount": 1,
+    "initialSyllable": "pan",
+    "finalSyllable": "pan",
+    "frequency": 3,
+    "category": "comida",
+    "structure": "CVC",
+    "difficulty": 3,
+    "image": null,
+    "needsReview": false
+  }
+]

--- a/src/data/words/index.js
+++ b/src/data/words/index.js
@@ -1,12 +1,82 @@
-import { level1Animals } from './animals.js';
-import { level1Home } from './home.js';
-import { level1Food } from './food.js';
-import { RAW_SPANISH_WORDS } from '../raw/spanishWords.js';
-import { buildProcessedWords } from '../../core/wordProcessor.js';
+const DATASET_URL = './src/data/processed/processedWords.json';
 
-const baseWords = [...level1Animals, ...level1Home, ...level1Food];
-const existingWords = new Set(baseWords.map((entry) => entry.word));
-const processedGeneralWords = buildProcessedWords(RAW_SPANISH_WORDS, { category: 'general' })
-  .filter((entry) => !existingWords.has(entry.word));
+export const WORDS = [];
 
-export const WORDS = [...baseWords, ...processedGeneralWords];
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function normalizeWordEntry(rawEntry) {
+  const word = normalizeText(rawEntry?.word);
+  const category = normalizeText(rawEntry?.category) || 'general';
+  const syllables = Array.isArray(rawEntry?.syllables)
+    ? rawEntry.syllables.map((item) => normalizeText(item)).filter(Boolean)
+    : [];
+
+  const difficulty = Number(rawEntry?.difficulty);
+  const frequency = Number(rawEntry?.frequency);
+
+  return {
+    id: String(rawEntry?.id || ''),
+    word,
+    syllables,
+    syllableCount: Number(rawEntry?.syllableCount),
+    initialSyllable: normalizeText(rawEntry?.initialSyllable),
+    finalSyllable: normalizeText(rawEntry?.finalSyllable),
+    difficulty,
+    frequency,
+    category,
+    structure: typeof rawEntry?.structure === 'string' ? rawEntry.structure.trim() : '',
+    image: rawEntry?.image ?? null,
+    needsReview: Boolean(rawEntry?.needsReview)
+  };
+}
+
+function hasValidGameShape(entry) {
+  return Boolean(
+    entry.id
+      && entry.word
+      && entry.structure
+      && Number.isInteger(entry.difficulty)
+      && Number.isInteger(entry.frequency)
+      && Array.isArray(entry.syllables)
+      && entry.syllables.length > 0
+      && entry.syllableCount === entry.syllables.length
+  );
+}
+
+export async function loadWordsDataset(datasetUrl = DATASET_URL) {
+  console.info(`[WORDS FLOW] Cargando dataset único desde: ${datasetUrl}`);
+
+  const response = await fetch(datasetUrl);
+  if (!response.ok) {
+    throw new Error(`No se pudo cargar ${datasetUrl} (${response.status}).`);
+  }
+
+  const payload = await response.json();
+  if (!Array.isArray(payload)) {
+    throw new Error(`Dataset inválido en ${datasetUrl}: debe ser un array.`);
+  }
+
+  const normalized = payload.map(normalizeWordEntry);
+  const valid = normalized.filter(hasValidGameShape);
+
+  WORDS.length = 0;
+  WORDS.push(...valid);
+
+  console.info('[WORDS FLOW] Dataset procesado', {
+    source: datasetUrl,
+    loaded: payload.length,
+    normalized: normalized.length,
+    validForGame: valid.length,
+    availableInGame: WORDS.length
+  });
+
+  return {
+    source: datasetUrl,
+    loaded: payload.length,
+    normalized: normalized.length,
+    validForGame: valid.length,
+    availableInGame: WORDS.length
+  };
+}

--- a/src/exercises/orderSyllables.js
+++ b/src/exercises/orderSyllables.js
@@ -45,6 +45,12 @@ function createSyllablePieces(syllables) {
 export function createOrderSyllablesRound(level = 1) {
   const config = resolveOrderLevel(level);
   const candidates = getLinguisticCandidates(config);
+  console.info('[WORDS FLOW] Generación de ronda', {
+    level: config.id,
+    filters: config.linguisticFilters,
+    candidates: candidates.length
+  });
+
   const word = getRandomWord(candidates);
 
   if (!word) {


### PR DESCRIPTION
### Motivation

- Simplificar el pipeline para que el juego use una sola fuente de verdad en lugar de mezclar datasets antiguos y módulos `animals.js`/`food.js`/etc. 
- Garantizar que al editar el corpus principal los cambios se reflejen automáticamente en el juego mediante un artefacto procesado listo para jugar. 
- Añadir trazas claras para depuración que indiquen origen, cantidad cargada, validadas y disponibles en el juego.

### Description

- Nuevo loader runtime en `src/data/words/index.js`: `loadWordsDataset` que solo carga y normaliza `src/data/processed/processedWords.json` y rellena `WORDS` con entradas válidas para el juego. 
- Cambios en `main.js` para llamar a `await loadWordsDataset()` en `init()` antes de ejecutar `validateWords(WORDS)` y así forzar un único flujo de datos. 
- Ajustes a `src/core/wordProcessor.js` para respetar la `category` presente en las entradas del corpus y generar `id` coherentes usando esa categoría cuando exista. 
- Script `scripts/processWords.mjs` que materializa el pipeline `spanishWordsCore.json -> buildProcessedWords(...) -> processedWords.json` y genera `src/data/processed/processedWords.json` listo para el juego. 
- Añadidos logs de depuración en carga de dataset y en la generación de rondas (`src/exercises/orderSyllables.js`) que informan origen, filtros y conteo de candidatas.

### Testing

- Ejecutado `node scripts/processWords.mjs` con éxito, el script escribió `src/data/processed/processedWords.json` y mostró logs de origen y conteos. 
- La ejecución del pipeline mostró validación de dataset sin errores (`[WORDS OK] Dataset validation completed without issues.`) y resultó en 5 entradas válidas en el ejemplo actual. 
- Se comprobó que `loadWordsDataset()` devuelve un resumen con `loaded`, `validForGame` y `availableInGame` que se registran en consola.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c798ed7d4832db7c0834de0820c80)