### PR TITLE
Fix exact count validation and add visual structural support

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,12 @@
 
           <p id="feedback" class="feedback idle">Piensa y responde.</p>
           <p id="reveal" class="reveal"></p>
+
+          <section id="visual-support" class="visual-support hidden" aria-live="polite">
+            <p id="support-title" class="support-title">Elige apoyo visual para continuar.</p>
+            <div id="support-actions" class="support-actions"></div>
+            <div id="support-boxes" class="support-boxes"></div>
+          </section>
         </section>
       </main>
     </section>

--- a/main.js
+++ b/main.js
@@ -16,12 +16,17 @@ const refs = {
   answerInput: document.querySelector('#answer-input'),
   submitBtn: document.querySelector('#submit-answer'),
   feedback: document.querySelector('#feedback'),
-  reveal: document.querySelector('#reveal')
+  reveal: document.querySelector('#reveal'),
+  visualSupport: document.querySelector('#visual-support'),
+  supportTitle: document.querySelector('#support-title'),
+  supportActions: document.querySelector('#support-actions'),
+  supportBoxes: document.querySelector('#support-boxes')
 };
 
 const state = {
   session: null,
-  challengeIndex: 0
+  challengeIndex: 0,
+  supportPendingFor: null
 };
 
 function goTo(view) {
@@ -38,6 +43,54 @@ function currentChallenge() {
   return state.session?.challenges[state.challengeIndex] || null;
 }
 
+function resetVisualSupport() {
+  state.supportPendingFor = null;
+  refs.visualSupport.classList.add('hidden');
+  refs.supportActions.innerHTML = '';
+  refs.supportBoxes.innerHTML = '';
+}
+
+function renderSupportBoxes(total) {
+  refs.supportBoxes.innerHTML = '';
+  for (let index = 0; index < total; index += 1) {
+    const box = document.createElement('span');
+    box.className = 'support-box';
+    box.setAttribute('aria-hidden', 'true');
+    refs.supportBoxes.appendChild(box);
+  }
+}
+
+function showVisualSupport() {
+  const session = state.session;
+  if (!session) return;
+
+  refs.visualSupport.classList.remove('hidden');
+  refs.supportTitle.textContent = 'Elige apoyo visual para continuar.';
+  refs.supportActions.innerHTML = '';
+
+  const supportModes = [
+    { key: 'syllables', label: 'Sílabas', count: session.syllableCount },
+    { key: 'letters', label: 'Letras', count: session.letters.length }
+  ];
+
+  supportModes.forEach((mode) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'support-choice-btn';
+    btn.textContent = `${mode.label} (${mode.count})`;
+    btn.addEventListener('click', () => {
+      refs.supportTitle.textContent = `${mode.label}: ${mode.count} piezas visuales.`;
+      renderSupportBoxes(mode.count);
+      setFeedback('ok', '¡Correcto! Observa la estructura y continúa.');
+      setTimeout(() => {
+        resetVisualSupport();
+        nextChallenge();
+      }, 650);
+    });
+    refs.supportActions.appendChild(btn);
+  });
+}
+
 function renderChallenge() {
   const challenge = currentChallenge();
   if (!challenge) {
@@ -48,6 +101,7 @@ function renderChallenge() {
     refs.answerInput.classList.add('hidden');
     refs.submitBtn.classList.add('hidden');
     refs.reveal.textContent = '';
+    resetVisualSupport();
     setFeedback('ok', 'Excelente trabajo metalingüístico.');
     return;
   }
@@ -57,6 +111,7 @@ function renderChallenge() {
   refs.prompt.textContent = challenge.prompt;
   refs.answerInput.value = '';
   refs.reveal.textContent = '';
+  resetVisualSupport();
   setFeedback('idle', 'Piensa y responde.');
 
   if (challenge.type === 'choice') {
@@ -94,8 +149,13 @@ function attemptAnswer(rawValue) {
   const isCorrect = engine.validateAnswer(challenge, rawValue);
 
   if (isCorrect) {
+    if (challenge.key === 'count_syllables' || challenge.key === 'count_letters') {
+      state.supportPendingFor = challenge.key;
+      showVisualSupport();
+      return;
+    }
+
     setFeedback('ok', '¡Correcto!');
-    refs.reveal.textContent = `Resultado: ${challenge.answer}`;
     nextChallenge();
     return;
   }

--- a/src/core/metalinguisticEngine.js
+++ b/src/core/metalinguisticEngine.js
@@ -44,7 +44,11 @@ function pickRandom(values) {
 }
 
 function normalizeAnswer(value) {
-  return normalizeInput(value).replace(/\s+/g, '');
+  return String(value || '')
+    .toUpperCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^A-Z0-9Ñ]/g, '');
 }
 
 function createChoiceOptions(correctValue, fallbackValues = []) {
@@ -122,7 +126,7 @@ function buildSession(baseWord) {
     answer: letters.filter((letter) => letter !== removableLetter).join('') || '∅'
   });
 
-  return { word, syllables, letters, challenges };
+  return { word, syllables, syllableCount: syllables.length, letters, challenges };
 }
 
 function validateAnswer(challenge, userAnswer) {

--- a/style.css
+++ b/style.css
@@ -88,3 +88,46 @@ input {
   .app-shell { width: 100%; min-height: 100dvh; margin: 0; }
   .view { min-height: 100dvh; border-radius: 0; }
 }
+
+.visual-support {
+  margin-top: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 16px;
+  padding: 14px;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(8, 15, 32, 0.78));
+}
+.support-title {
+  font-size: 1rem;
+  color: #cbd5e1;
+}
+.support-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+.support-choice-btn {
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: rgba(14, 27, 49, 0.9);
+  color: var(--text);
+  font-weight: 700;
+  padding: 10px 14px;
+  cursor: pointer;
+}
+.support-choice-btn:hover {
+  border-color: var(--accent);
+}
+.support-boxes {
+  margin-top: 14px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(44px, 1fr));
+  gap: 10px;
+}
+.support-box {
+  height: 46px;
+  border-radius: 12px;
+  border: 1px solid rgba(226, 232, 240, 0.35);
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.86), rgba(15, 23, 42, 0.86));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}


### PR DESCRIPTION
### Motivation
- Corregir la validación para que los retos de conteo (`sílabas`/`letras`) solo acepten la respuesta numérica exacta y evitar coincidencias falsas por normalización incorrecta. 
- Añadir un apoyo visual minimalista (cuadrados vacíos) tras el acierto en retos de conteo para facilitar la representación mental sin revelar la palabra. 
- Mantener la arquitectura, el diseño fullscreen moderno y el comportamiento de reintento suave sin mostrar soluciones.

### Description
- Ajusté la normalización de respuestas en `src/core/metalinguisticEngine.js` con `normalizeAnswer` para preservar/detectar dígitos y normalizar acentos, y añadí `syllableCount` al objeto de sesión devuelto por `buildSession`.  
- Conservé `validateAnswer` como comparación estricta tras normalizar, de modo que ahora solo pasa si la respuesta coincide exactamente con el valor esperado.  
- Añadí la sección de apoyo visual en `index.html` (`#visual-support`) y estilos modernos en `style.css` para piezas grandes, limpias y táctiles que no muestran letras ni sílabas.  
- Implementé el flujo UI en `main.js` con `showVisualSupport`, `renderSupportBoxes` y `resetVisualSupport`, activado solo cuando se aciertan los retos `count_syllables` o `count_letters`, usando los datos reales `syllableCount` y `letters.length` del motor.

### Testing
- Ejecuté la comprobación estática de sintaxis con `node --check main.js && node --check src/core/metalinguisticEngine.js` y ambas pasaron correctamente.
- Verifiqué en ejecución local la interacción básica: conteos requieren la respuesta exacta, el apoyo visual aparece tras acierto y los errores permiten reintento sin revelar la solución.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c89129fa8832da2b6e707ed680cc4)