### PR TITLE
Fix syllable splitting: use curated WORDS and robust Spanish syllabifier

### DIFF
--- a/src/core/metalinguisticEngine.js
+++ b/src/core/metalinguisticEngine.js
@@ -1,36 +1,37 @@
 import { WORDS } from '../data/words/index.js';
+import { syllabifySpanishWord } from './wordProcessor.js';
 
-const VOWELS = new Set(['A', 'E', 'I', 'O', 'U', 'Á', 'É', 'Í', 'Ó', 'Ú', 'Ü']);
 
 const normalize = (raw) => String(raw || '')
   .toUpperCase()
   .normalize('NFD')
   .replace(/[^A-ZÑ]/g, '');
 
+const WORD_SYLLABLES = new Map(
+  WORDS
+    .filter((entry) => entry?.word && Array.isArray(entry?.syllables) && entry.syllables.length > 0)
+    .map((entry) => [
+      normalize(entry.word),
+      entry.syllables
+        .map((part) => normalize(part))
+        .filter(Boolean)
+    ])
+    .filter(([, syllables]) => syllables.length > 0)
+);
+
 function splitSyllables(word) {
   if (!word) return [];
 
-  const letters = [...word];
-  const syllables = [];
-  let current = '';
+  const normalizedWord = normalize(word);
+  const knownSyllables = WORD_SYLLABLES.get(normalizedWord);
+  if (knownSyllables) return [...knownSyllables];
 
-  for (let i = 0; i < letters.length; i += 1) {
-    const letter = letters[i];
-    const next = letters[i + 1];
-    current += letter;
-
-    if (VOWELS.has(letter) && (!next || VOWELS.has(next))) {
-      syllables.push(current);
-      current = '';
-    }
+  const { syllables } = syllabifySpanishWord(normalizedWord);
+  if (Array.isArray(syllables) && syllables.length > 0) {
+    return syllables.map((part) => normalize(part));
   }
 
-  if (current) {
-    if (syllables.length) syllables[syllables.length - 1] += current;
-    else syllables.push(current);
-  }
-
-  return syllables;
+  return [normalizedWord];
 }
 
 function randomOf(list) {


### PR DESCRIPTION
### Motivation
- The previous `splitSyllables` heuristic collapsed most words into a single syllable, breaking syllable-mode exercises (e.g., words like "cuadrados" or "rosas").
- The change aims to produce accurate syllable segmentation by preferring curated data and a proper syllabifier instead of a naive vowel-boundary rule.

### Description
- Added a `WORD_SYLLABLES` lookup built from `WORDS` so known words use curated syllable splits via `normalize(entry.word)` and stored syllable parts. 
- Replaced the simplistic vowel-boundary logic in `splitSyllables` with a prioritized flow that returns `WORD_SYLLABLES` when available. 
- For unknown words, `splitSyllables` now calls `syllabifySpanishWord` from `src/core/wordProcessor.js` and returns normalized syllable parts when available. 
- Kept a final safe fallback of returning the normalized whole word in an array only if syllabification fails.

### Testing
- Imported the engine and ran a Node smoke check with `createMetalinguisticEngine().splitSyllables` confirming `CUADRADOS -> ['CUA','DRA','DOS']`, `ROSAS -> ['RO','SAS']`, and `TOMATE -> ['TO','MA','TE']`.
- Import-time dataset validation ran and reported `[WORDS OK] Dataset validation completed without issues.`
- The smoke checks completed successfully and produced the expected segmented outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8ee62e9c832daabf4d9892ecf29f)