### PR TITLE
Añade selector inicial de sílabas y letras con validación y animación de error

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,25 @@
     <p class="eyebrow">LEXIA</p>
     <h1 id="word-display" class="word">TOMATE</h1>
 
+    <section id="setup-zone" class="setup-zone" aria-label="Selector inicial">
+      <p class="setup-title">Primero selecciona cuántas sílabas y letras tiene la palabra.</p>
+      <div class="setup-controls">
+        <label>
+          Sílabas
+          <select id="syllables-select">
+            <option value="">Selecciona</option>
+          </select>
+        </label>
+        <label>
+          Letras
+          <select id="letters-select">
+            <option value="">Selecciona</option>
+          </select>
+        </label>
+        <button id="setup-btn" type="button">Validar</button>
+      </div>
+    </section>
+
     <section class="tiles-zone" aria-label="Representación estructural">
       <div id="tiles" class="tiles"></div>
     </section>

--- a/main.js
+++ b/main.js
@@ -9,6 +9,10 @@ const refs = {
   answerForm: document.querySelector('#answer-form'),
   answerInput: document.querySelector('#answer-input'),
   feedback: document.querySelector('#feedback'),
+  setupZone: document.querySelector('#setup-zone'),
+  syllablesSelect: document.querySelector('#syllables-select'),
+  lettersSelect: document.querySelector('#letters-select'),
+  setupBtn: document.querySelector('#setup-btn'),
   modeBtn: document.querySelector('#mode-btn'),
   nextBtn: document.querySelector('#next-btn'),
   wordBtn: document.querySelector('#word-btn')
@@ -17,8 +21,30 @@ const refs = {
 const state = {
   mode: 'syllables',
   word: 'TOMATE',
-  challenge: null
+  challenge: null,
+  setupDone: false
 };
+
+function expectedStructure() {
+  return {
+    syllables: engine.splitSyllables(state.word).length,
+    letters: state.word.length
+  };
+}
+
+function fillSetupSelectors() {
+  const limits = { syllables: 6, letters: 12 };
+  refs.syllablesSelect.innerHTML = '<option value="">Selecciona</option>';
+  refs.lettersSelect.innerHTML = '<option value="">Selecciona</option>';
+
+  for (let i = 1; i <= limits.syllables; i += 1) {
+    refs.syllablesSelect.insertAdjacentHTML('beforeend', `<option value="${i}">${i}</option>`);
+  }
+
+  for (let i = 1; i <= limits.letters; i += 1) {
+    refs.lettersSelect.insertAdjacentHTML('beforeend', `<option value="${i}">${i}</option>`);
+  }
+}
 
 function setFeedback(kind, text) {
   refs.feedback.className = `feedback ${kind}`;
@@ -26,6 +52,11 @@ function setFeedback(kind, text) {
 }
 
 function renderTiles() {
+  if (!state.setupDone) {
+    refs.tiles.innerHTML = '';
+    return;
+  }
+
   const total = state.mode === 'syllables'
     ? state.challenge.baseParts.length
     : state.word.length;
@@ -40,12 +71,16 @@ function renderTiles() {
 
 function loadChallenge() {
   state.challenge = engine.createChallenge(state.word, state.mode);
+  state.setupDone = false;
   refs.word.textContent = state.word;
   refs.instruction.textContent = state.challenge.instruction;
   refs.answerInput.value = '';
+  refs.syllablesSelect.value = '';
+  refs.lettersSelect.value = '';
+  refs.setupZone.classList.remove('shake');
   renderTiles();
-  setFeedback('idle', 'Piensa la palabra y escríbela.');
-  refs.answerInput.focus();
+  setFeedback('idle', 'Selecciona sílabas y letras para empezar.');
+  refs.syllablesSelect.focus();
 }
 
 function newWord() {
@@ -55,6 +90,14 @@ function newWord() {
 
 refs.answerForm.addEventListener('submit', (event) => {
   event.preventDefault();
+  if (!state.setupDone) {
+    setFeedback('error', 'Primero valida sílabas y letras.');
+    refs.setupZone.classList.remove('shake');
+    void refs.setupZone.offsetWidth;
+    refs.setupZone.classList.add('shake');
+    return;
+  }
+
   const answer = refs.answerInput.value;
 
   if (engine.isCorrect(state.challenge, answer)) {
@@ -71,6 +114,29 @@ refs.answerForm.addEventListener('submit', (event) => {
   refs.answerInput.select();
 });
 
+refs.setupBtn.addEventListener('click', () => {
+  const selectedSyllables = Number(refs.syllablesSelect.value);
+  const selectedLetters = Number(refs.lettersSelect.value);
+  const expected = expectedStructure();
+  const ok = selectedSyllables === expected.syllables && selectedLetters === expected.letters;
+
+  if (!ok) {
+    state.setupDone = false;
+    renderTiles();
+    setFeedback('error', 'No coincide. Revisa y vuelve a intentar.');
+    refs.setupZone.classList.remove('shake');
+    void refs.setupZone.offsetWidth;
+    refs.setupZone.classList.add('shake');
+    return;
+  }
+
+  state.setupDone = true;
+  refs.setupZone.classList.remove('shake');
+  renderTiles();
+  setFeedback('ok', '¡Correcto! Ahora resuelve la consigna.');
+  refs.answerInput.focus();
+});
+
 refs.modeBtn.addEventListener('click', () => {
   state.mode = state.mode === 'syllables' ? 'letters' : 'syllables';
   refs.modeBtn.textContent = state.mode === 'syllables' ? 'Modo: Sílabas' : 'Modo: Letras';
@@ -80,4 +146,5 @@ refs.modeBtn.addEventListener('click', () => {
 refs.nextBtn.addEventListener('click', loadChallenge);
 refs.wordBtn.addEventListener('click', newWord);
 
+fillSetupSelectors();
 newWord();

--- a/style.css
+++ b/style.css
@@ -31,6 +31,24 @@ body {
 }
 .eyebrow { margin: 0; color: var(--muted); letter-spacing: .12em; text-transform: uppercase; }
 .word { margin: 0; font-size: clamp(2.6rem, 10vw, 6rem); letter-spacing: 0.1em; }
+.setup-zone {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  padding: 14px;
+  background: rgba(12, 20, 37, 0.6);
+}
+.setup-title { margin: 0 0 10px; color: var(--muted); }
+.setup-controls { display: flex; flex-wrap: wrap; gap: 10px; align-items: end; }
+.setup-controls label { display: grid; gap: 6px; font-weight: 600; }
+.setup-controls select {
+  font: inherit;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  padding: 10px 12px;
+  background: rgba(7, 13, 25, 0.9);
+  color: var(--text);
+  min-width: 130px;
+}
 .tiles-zone {
   min-height: clamp(130px, 24vw, 180px);
   border: 1px solid var(--line);
@@ -79,7 +97,15 @@ button {
 .feedback.error { color: var(--error); }
 .controls { display: flex; gap: 10px; flex-wrap: wrap; }
 .pulse { animation: pulse .4s ease 0s 2; }
+.shake { animation: shake .35s ease; }
 @keyframes pulse { 50% { transform: scale(1.04); } }
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20% { transform: translateX(-8px); }
+  40% { transform: translateX(8px); }
+  60% { transform: translateX(-6px); }
+  80% { transform: translateX(6px); }
+}
 
 @media (max-width: 680px) {
   .app { grid-template-rows: auto auto auto auto auto auto; }


### PR DESCRIPTION
### Motivation
- Introducir un paso inicial que haga al usuario identificar la estructura de la palabra (número de sílabas y de letras) antes de resolver la consigna para reforzar la conciencia metalingüística.
- Dar retroalimentación visual clara cuando la selección es incorrecta para mejorar la usabilidad y el aprendizaje inmediato.

### Description
- Se agregó la sección `setup-zone` en `index.html` con dos selectores (`#syllables-select`, `#letters-select`) y el botón `#setup-btn` para validar la selección. 
- En `main.js` se añadió el estado `setupDone`, las funciones `expectedStructure` y `fillSetupSelectors`, bloqueo de envío hasta validar la selección, y renderizado condicional de los cuadrados sólo cuando la validación es correcta. 
- Si la validación falla se muestra feedback de error y se aplica la animación `shake`; si es correcta se habilita la actividad y se muestra feedback positivo. 
- Se actualizaron estilos en `style.css` para el bloque inicial y se añadieron keyframes `shake` para la vibración de error. 

### Testing
- Ejecutado `node --check main.js` para validar la sintaxis del script y pasó correctamente. 
- Verificada la presencia de cambios con `git status --short` antes del commit. 
- Se creó el commit con los tres archivos modificados (`index.html`, `main.js`, `style.css`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c913a4f94832da7841a02dcbc1df7)